### PR TITLE
styling

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ By the end of this workshop, students will know how to:
 > ## Note
 > 
 > - This is the draft HPC Carpentry release. Comments and feedback are welcome.
-> - Link to https://hpc-carpentry.github.io/hpc-shell/ when that is complete.
+> - Link to [hpc-shell](https://hpc-carpentry.github.io/hpc-shell/) when that is complete.
 {: .callout}
 
 > ## Prerequisites

--- a/index.md
+++ b/index.md
@@ -19,6 +19,5 @@ By the end of this workshop, students will know how to:
 >
 > Command line experience is necessary for this lesson. We recommend the participants 
 > to go through https://swcarpentry.github.io/shell-novice/ if new to the terminal. 
-
 {: .prereq}
 

--- a/index.md
+++ b/index.md
@@ -12,8 +12,11 @@ By the end of this workshop, students will know how to:
 * Use the UNIX command line to operate a computer, connect to a cluster, and write simple shell scripts.
 * Submit and manage jobs on a cluster using a scheduler, transfer files, and use software through environment modules.
 
-**NOTE: This is the draft HPC Carpentry release. Comments and feedback are welcome.** 
-**NOTE 2: Link to https://hpc-carpentry.github.io/hpc-shell/ when that is complete.**
+> ## Note
+> 
+> - This is the draft HPC Carpentry release. Comments and feedback are welcome.
+> - Link to https://hpc-carpentry.github.io/hpc-shell/ when that is complete.
+{: .callout}
 
 > ## Prerequisites
 >


### PR DESCRIPTION
Ran `make lesson-check`, which found a stray space in `intro.md`.
Also reformatted the "NOTE" and "NOTE2" blurbs as [Special Blockquotes](https://carpentries.github.io/lesson-example/04-formatting/#special-blockquotes) with `{: .callout}` styling.