### PR TITLE
Contributors

### DIFF
--- a/.github/codeowners
+++ b/.github/codeowners
@@ -1,0 +1,9 @@
+# This file lists the contributors responsible for the
+# repository content. They will also be automatically
+# asked to review any pull request made in this repository.
+
+# Each line is a file pattern followed by one or more owners.
+# The sequence matters: later patterns take precedence.
+
+*       steinbach@scionics.de ckoch5@wisc.edu
+

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,12 @@
-FIXME: list authors' names and email addresses.
+HPC Intro is maintained by
+
+- [Christina Koch](mailto:ckoch5@wisc.edu)
+- [Peter Steinbach](mailto:steinbach@scionics.de)
+
+It was written and edited by
+
+- [@ChristinaLK](https://github.com/ChristinaLK]
+- [@jstaf](https://github.com/jstaf)
+- [@psteinb](https://github.com/psteinb]
+- [@symulation](https://github.com/symulation)
+- [@tkphd](https://github.com/tkphd]


### PR DESCRIPTION
List lesson authors (based on a review of commit history) and specify code owners.
Related to the [discuss-hpc discussion on maintainers](https://carpentries.topicbox.com/groups/maintainers-hpc/Tb2fe0958afeb3186/who-is-actually-a-maintainer).