### PR TITLE
Attempt to fix base-url on deployed site.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -105,4 +105,3 @@ exclude:
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge
-

--- a/_episodes/11-hpc-intro.md
+++ b/_episodes/11-hpc-intro.md
@@ -56,7 +56,7 @@ Let's dissect what resources programs running on a laptop require:
 
 Schematically, this can be reduced to the following:
 
-{% include figure.html url="" max-width="30%" file="/fig/Simple_Von_Neumann_Architecture.svg" alt="Schematic of how a computer works"
+{% include figure.html max-width="30%" file="/fig/Simple_Von_Neumann_Architecture.svg" alt="Schematic of how a computer works"
 caption="" %}
 
 

--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,7 +1,11 @@
 <figure>
-   <a href="{{ include.url }}">
-   <img src="{{ include.file }}" style="max-width: {{ include.max-width }};"
-      alt="{{ include.alt }}"/>
+   {% if include.url != "" %}
+    <a href="{{ include.url }}">
+   {% endif %}
+   <img src="{{ include.file | relative_url}}" style="max-width: {{ include.max-width }};"
+      alt="{{ include.alt | relative_url}}"/>
+   {% if include.url != "" %}
    </a>
+   {% endif %}
    <figcaption>{{ include.caption }}</figcaption>
 </figure>


### PR DESCRIPTION
As afar as I understand doing so should prepend the baseURL to the
figure thus making the figure correctly appear in gh pages.

It seem to work locally when forcing the baseurl with the --baseurl
flag.

Also when URL for figure is not set, do not inject the a tag which
create an empty link.