### PR TITLE
Update 13-scheduler.md

### DIFF
--- a/_episodes/13-scheduler.md
+++ b/_episodes/13-scheduler.md
@@ -174,7 +174,7 @@ stuck with your site's default resources, which is probably not what we want.
 
 The following are several key resource requests:
 
-* `-n <nnodes>` - how many nodes does your job need? 
+* `-N <nnodes>` - how many nodes does your job need? 
 
 * `-c <ncpus>` - How many CPUs does your job need?
 


### PR DESCRIPTION
Should be capital N for nodes -N
-n is number of tasks

-n, --ntasks=<number>
              sbatch does not launch tasks, it requests an allocation of resources and submits a batch script. This option advises the Slurm  controller  that  job  steps  run
              within  the  allocation  will  launch  a  maximum  of  number tasks and to provide for sufficient resources.  The default is one task per node, but note that the
              --cpus-per-task option will change this default.