### PR TITLE
Suggest more customization using site variables [WIP]

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -78,7 +78,7 @@ scheduler: "slurm"
 login_host: "cray-1"
 cluster_name: "cray-1"
 shared_fast_filesystem: "/fastfs"
-
+ls_user_home_output: "README"
 
 # Specify that things in the episodes collection should be output.
 collections:

--- a/_episodes/12-cluster.md
+++ b/_episodes/12-cluster.md
@@ -91,6 +91,7 @@ $ ls
 {: .language-bash}
 
 ~~~ 
+{{ site.ls_user_home_output }}
 ~~~
 {: .output}
 


### PR DESCRIPTION
Suggest more customization after using the material with other cluster with differing setups. 

1. include site.ls_user_home_output, so different ls out puts can be showing for different cluster setups Fixes #94