### PR TITLE
Broken URL

### DIFF
--- a/_episodes/15-transferring-files.md
+++ b/_episodes/15-transferring-files.md
@@ -26,7 +26,7 @@ The syntax is: `wget https://some/link/to/a/file.tar.gz`. For example, download 
 lesson sample files using the following command:
 
 ```
-{{ site.host_prompt }} wget {{ site.url }}{{ site.baseurl }}/bash-lesson.tar.gz
+{{ site.host_prompt }} wget {{ site.url }}{{ site.baseurl }}/files/bash-lesson.tar.gz
 ```
 {: .bash}
 


### PR DESCRIPTION
The 'files' directory is missing so the rendered URL is broken.

The  currently rendered broken URL can be found on this page: https://hpc-carpentry.github.io/hpc-intro/15-transferring-files/index.html

Fixes #120 