### PR TITLE
👷 allows "namd" as a word so the spelling doesn't fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ jobs:
       # Use codespell for spell checking
       install:
         pip install codespell
-      script: codespell --skip="assets,*.svg,bin" --quiet-level=2  --ignore-words-list="rouge,dropse" -L "namd"
+      script: codespell --skip="assets,*.svg,bin" --quiet-level=2  -L "rouge,dropse,namd"
     - stage: check_and_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ jobs:
       # Use codespell for spell checking
       install:
         pip install codespell
-      script: codespell --skip="assets,*.svg,bin" --quiet-level=2  --ignore-words-list="rouge,dropse"
+      script: codespell --skip="assets,*.svg,bin" --quiet-level=2  --ignore-words-list="rouge,dropse" -L "namd"
     - stage: check_and_build


### PR DESCRIPTION
It may have been a recent update on `codespell` but now `namd` (a library mentioned in some places) is making the CI to fail. This list will probably grow as people add more examples for different HPC, so I don't know when the codespell will become useless by allowing many libraries.