### PR TITLE
Update lesson 13 to be compatible with Sun Grid Engine

### DIFF
--- a/_episodes/13-scheduler.md
+++ b/_episodes/13-scheduler.md
@@ -92,6 +92,7 @@ the *queue*. To check on our job's status, we check the queue using the command
 ```
 {{ site.host_prompt }} {{ site.sched_status }} {{ site.sched_flag_user }}
 ```
+{: .bash}
 {% include /snippets/13/statu_output.snip %}
 
 The best way to check our job's status is with `{{ site.sched_status }}`.

--- a/_episodes/13-scheduler.md
+++ b/_episodes/13-scheduler.md
@@ -66,6 +66,7 @@ run as a test.
 > echo 'This script is running on:'
 > hostname
 > sleep 120
+> echo 'This script has finished successfully'
 > ```
 > {: .bash}
 {: .challenge}
@@ -91,15 +92,10 @@ the *queue*. To check on our job's status, we check the queue using the command
 ```
 {{ site.host_prompt }} {{ site.sched_status }} {{ site.sched_flag_user }}
 ```
-{: .bash}
-```
 {% include /snippets/13/statu_output.snip %}
-```
-{: .output}
 
-We can see all the details of our job, most importantly that it is in the "R" or "RUNNING" state.
-Sometimes our jobs might need to wait in a queue ("PENDING") or have an error. The best way to check
-our job's status is with `{{ site.sched_status }}`. Of course, running `{{ site.sched_status }}` repeatedly to check on things can be
+The best way to check our job's status is with `{{ site.sched_status }}`.
+Of course, running `{{ site.sched_status }}` repeatedly to check on things can be
 a little tiresome. To see a real-time view of our jobs, we can use the `watch` command. `watch`
 reruns a given command at 2-second intervals. This is too frequent, and will likely upset your system
 administrator. You can change the interval to a more reasonable value, for example 60 seconds, with the
@@ -135,12 +131,13 @@ Let's illustrate this by example. By default, a job's name is the name of the sc
 Submit the following job (`{{ site.sched_submit }} {{ site.sched_submit_options }} example-job.sh`):
 
 ```
-#!/bin/bash
+#!/bin/bash -l
 {{ site.sched_comment }} {{ site.sched_flag_name }} new_name
 
 echo 'This script is running on:'
 hostname
 sleep 120
+> echo 'This script has finished successfully'
 ```
 
 ```

--- a/_extras/snippets_library/EPCC_Cirrus_pbs/13/long_job.snip
+++ b/_extras/snippets_library/EPCC_Cirrus_pbs/13/long_job.snip
@@ -4,3 +4,4 @@
 echo 'This script is running on:'
 hostname
 sleep 120
+echo 'This script has finished successfully'

--- a/_extras/snippets_library/EPCC_Cirrus_pbs/13/statu_output.snip
+++ b/_extras/snippets_library/EPCC_Cirrus_pbs/13/statu_output.snip
@@ -1,6 +1,11 @@
-
+{: .bash}
+```
 indy2-login0: 
                                                             Req'd  Req'd   Elap
 Job ID          Username Queue    Jobname    SessID NDS TSK Memory Time  S Time
 --------------- -------- -------- ---------- ------ --- --- ------ ----- - -----
 387775.indy2-lo yourUser workq    example-jo  50804   1   1    --  96:00 R 00:00
+```
+{: .output}
+We can see all the details of our job, most importantly that it is in the `R` or `RUNNING` state.
+Sometimes our jobs might need to wait in a queue (`PENDING`) or have an error (`E`).

--- a/_extras/snippets_library/EPCC_Cirrus_pbs/13/statu_output.snip
+++ b/_extras/snippets_library/EPCC_Cirrus_pbs/13/statu_output.snip
@@ -1,4 +1,3 @@
-{: .bash}
 ```
 indy2-login0: 
                                                             Req'd  Req'd   Elap

--- a/_includes/snippets/13/long_job.snip
+++ b/_includes/snippets/13/long_job.snip
@@ -4,3 +4,4 @@
 echo 'This script is running on:'
 hostname
 sleep 120
+echo 'This script has finished successfully'

--- a/_includes/snippets/13/statu_output.snip
+++ b/_includes/snippets/13/statu_output.snip
@@ -1,4 +1,3 @@
-{: .bash}
 ```
 JOBID USER         ACCOUNT     NAME           ST REASON START_TIME         TIME TIME_LEFT NODES CPUS
 36856 yourUsername yourAccount example-job.sh R  None   2017-07-01T16:47:02 0:11 59:49     1     1

--- a/_includes/snippets/13/statu_output.snip
+++ b/_includes/snippets/13/statu_output.snip
@@ -1,2 +1,8 @@
+{: .bash}
+```
 JOBID USER         ACCOUNT     NAME           ST REASON START_TIME         TIME TIME_LEFT NODES CPUS
 36856 yourUsername yourAccount example-job.sh R  None   2017-07-01T16:47:02 0:11 59:49     1     1
+```
+{: .output}
+We can see all the details of our job, most importantly that it is in the `R` or `RUNNING` state.
+Sometimes our jobs might need to wait in a queue (`PENDING`) or have an error (`E`).


### PR DESCRIPTION
* Add a line ‘This scripts has finished successfully’ to example scripts to be able to tell when it didn’t do so. The sge scheduler doesn’t give an error when jobs time out.
* Move scheduler flags from the lesson body text to `statu_output.snip` because they can vary for different schedulers