### PR TITLE
Quick fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ files/*.gtf
 files/*.fb
 files/*.fastq
 files/*.tsv
+Gemfile.lock
 scratch/
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 .DS_Store
 .ipynb_checkpoints
+.jekyll-cache
 .sass-cache
 __pycache__
 _site

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ before_script:
 pages:
   stage: deploy
   script:
-   - jekyll build -s jekyll -d public
+   - jekyll build -d public
   artifacts:
     paths:
     - public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,22 @@
+# .gitlab-ci.yml for generating a Jekyll based site.
+#
+# Based on the example from
+#    https://gitlab.com/pages/jekyll/blob/master/.gitlab-ci.yml
+image: ruby:latest
+
+variables:
+  JEKYLL_ENV: production
+
+before_script:
+  - gem install bundler
+  - bundle install
+
+pages:
+  stage: deploy
+  script:
+   - jekyll build -s jekyll -d public
+  artifacts:
+    paths:
+    - public
+  only:
+  - ctcms

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ branches:
 before_install:
   - sudo apt-get update -y
   - rvm default
-  - gem install json kramdown jekyll
+  - gem install bundler
+  - bundle install
 install:
   - pip install pyyaml
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+ruby RUBY_VERSION
+
+# This will help ensure the proper Jekyll version is running.
+gem "jekyll", "3.4.0"
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/_episodes/11-hpc-intro.md
+++ b/_episodes/11-hpc-intro.md
@@ -33,15 +33,13 @@ they started:
 
 In all these cases, what is needed is access to more computers than can be used at the same time.
 
-> # And what do you do?
+> ## And what do you do?
 > 
 > Talk to your neighbour, office mate or [rubber duck](https://rubberduckdebugging.com/) about your
 > research. How does computing help you do your research? 
 > How could more computing help you do more or better research?
 {: .challenge }
 
-
-# Doing Analysis or Running Code
 
 ## A standard Laptop for standard tasks
 
@@ -100,7 +98,7 @@ prospect users:
 1. they work with the command line (not a GUI style user interface)
 2. they work with a distributed set of computers (called nodes)
 
-> # I've never used a server, have I?
+> ## I've never used a server, have I?
 > 
 > Take a minute and think about which of your daily interactions with a computer may require a 
 > remote server or even cluster to provide you with results. 

--- a/_episodes/12-cluster.md
+++ b/_episodes/12-cluster.md
@@ -46,6 +46,7 @@ The word before the `@` symbol, e.g. `yourUsername` here, is the user account na
 permissions for on the cluster. 
 
 > ## Where do I get this `ssh` from ?
+>
 > On Linux and/or macOS, the `ssh` command line utility is almost always pre-installed. Open a
 > terminal and type `ssh --help` to check if that is the case. 
 > 
@@ -102,6 +103,7 @@ For example, we can view all of the worker nodes with the `{{ site.sched_info }}
 {{ site.host_prompt}} {{ site.sched_info }}
 ```
 {: .bash}
+
 ```
 {% include /snippets/12/info.snip %}
 ```
@@ -113,6 +115,7 @@ directly, they enable a number of key features like ensuring our user account an
 available throughout the HPC system.
 
 > ## Shared file systems
+>
 > This is an important point to remember: files saved on one node (computer) are often available
 > everywhere on the cluster!
 {: .callout}
@@ -158,12 +161,14 @@ been restarted.
 > You can get more detailed information on both the processors and memory by using different commands.
 >
 > For more information on processors use `lscpu`
+>
 > ```
 > {{ site.host_prompt}} lscpu
 > ```
 > {: .language-bash}
 >
 > For more information on memory you can look in the `/proc/meminfo` file:
+>
 > ```
 > {{ site.host_prompt}} cat /proc/meminfo
 > ```
@@ -197,6 +202,7 @@ been restarted.
 {: .callout}
 
 > ## Differences Between Nodes
+>
 > Many HPC clusters have a variety of nodes optimized for particular workloads. Some nodes
 > may have larger amount of memory, or specialized resources such as Graphical Processing Units
 > (GPUs).

--- a/_episodes/13-scheduler.md
+++ b/_episodes/13-scheduler.md
@@ -19,6 +19,7 @@ keypoints:
 ---
 
 ## Job scheduler
+
 An HPC system might have thousands of nodes and thousands of users. How do we decide who gets what
 and when? How do we ensure that a task is run with the resources it needs? This job is handled by a
 special piece of software called the scheduler. On an HPC system, the scheduler manages which jobs
@@ -42,9 +43,9 @@ alt="Compare a job scheduler to a waiter in a restaurant" caption="" %}
 > [*notes for the instructor here*](../guide)
 {: .challenge}
 
-The scheduler used in this lesson is {{ site.sched_name }}. Although {{ site.sched_name }} is not used everywhere,
-running jobs is quite similar regardless of what software is being used. The exact syntax might change, but the
-concepts remain the same.
+The scheduler used in this lesson is {{ site.sched_name }}. Although {{ site.sched_name }} is not
+used everywhere, running jobs is quite similar regardless of what software is being used. The exact
+syntax might change, but the concepts remain the same.
 
 ## Running a batch job
 
@@ -78,6 +79,7 @@ to the scheduler, we use the `{{ site.sched_submit }}` command.
 [{{ site.host_prompt }} {{ site.sched_submit }} {{ site.sched_submit_options }} example-job.sh
 ```
 {: .bash}
+
 ```
 {% include /snippets/13/submit_output.snip %}
 ```
@@ -92,6 +94,7 @@ the *queue*. To check on our job's status, we check the queue using the command
 {{ site.host_prompt }} {{ site.sched_status }} {{ site.sched_flag_user }}
 ```
 {: .bash}
+
 ```
 {% include /snippets/13/statu_output.snip %}
 ```
@@ -99,11 +102,12 @@ the *queue*. To check on our job's status, we check the queue using the command
 
 We can see all the details of our job, most importantly that it is in the "R" or "RUNNING" state.
 Sometimes our jobs might need to wait in a queue ("PENDING") or have an error. The best way to check
-our job's status is with `{{ site.sched_status }}`. Of course, running `{{ site.sched_status }}` repeatedly to check on things can be
-a little tiresome. To see a real-time view of our jobs, we can use the `watch` command. `watch`
-reruns a given command at 2-second intervals. This is too frequent, and will likely upset your system
-administrator. You can change the interval to a more reasonable value, for example 60 seconds, with the
-`-n 60` parameter. Let's try using it to monitor another job.
+our job's status is with `{{ site.sched_status }}`. Of course, running `{{ site.sched_status }}`
+repeatedly to check on things can be a little tiresome. To see a real-time view of our jobs, we can
+use the `watch` command. `watch` reruns a given command at 2-second intervals. This is too frequent,
+and will likely upset your system administrator. You can change the interval to a more reasonable
+value, for example 60 seconds, with the `-n 60` parameter. Let's try using it to monitor another
+job.
 
 ```
 {{ site.host_prompt }} {{ site.sched_submit }} {{ site.sched_submit_options }} example-job.sh
@@ -142,11 +146,13 @@ echo 'This script is running on:'
 hostname
 sleep 120
 ```
+{:.bash}
 
 ```
 {{ site.host_prompt }} {{ site.sched_status }} {{ site.sched_flag_user }}
 ```
 {: .bash}
+
 ```
 {% include /snippets/13/statu_name_output.snip %}
 ```
@@ -192,6 +198,7 @@ minutes.
 ```
 {% include /snippets/13/long_job.snip %}
 ```
+{:.bash}
 
 Submit the job and wait for it to finish. Once it is has finished, check the log file.
 
@@ -201,6 +208,7 @@ Submit the job and wait for it to finish. Once it is has finished, check the log
 {% include /snippets/13/long_job_cat.snip %}
 ```
 {: .bash}
+
 ```
 {% include /snippets/13/long_job_err.snip %}
 ```
@@ -227,6 +235,7 @@ walltime so that it runs long enough for you to cancel it before it is killed!).
 {{ site.host_prompt }} {{ site.sched_status }} {{ site.sched_flag_user }}
 ```
 {: .bash}
+
 ```
 {% include /snippets/13/del_job_output1.snip %}
 ```
@@ -237,10 +246,11 @@ successfully cancelled.
 
 ```
 {% include /snippets/13/del_job.snip %}
-... Note that it might take a minute for the job to disappear from the queue ...
+# ... Note that it might take a minute for the job to disappear from the queue ...
 {{ site.host_prompt }} {{ site.sched_status }} {{ site.sched_flag_user }}
 ```
 {: .bash}
+
 ```
 {% include /snippets/13/del_job_output2.snip %}
 ```

--- a/_episodes/14-modules.md
+++ b/_episodes/14-modules.md
@@ -19,9 +19,9 @@ software package, we will need to "load" it ourselves.
 Before we start using individual software packages, however, we should understand the reasoning
 behind this approach. The three biggest factors are:
 
-- software incompatibilities;
-- versioning;
-- dependencies.
+- software incompatibilities
+- versioning
+- dependencies
 
 Software incompatibility is a major headache for programmers. Sometimes the presence (or absence) of
 a software package will break others that depend on it. Two of the most famous examples are Python 2
@@ -70,6 +70,7 @@ so
 {{ site.host_prompt }} module list
 ```
 {: .bash}
+
 ```
 No Modulefiles Currently Loaded.
 ```
@@ -83,6 +84,7 @@ To see available software modules, use `module avail`
 {{ site.host_prompt }} module avail
 ```
 {: .bash}
+
 ```
 {% include /snippets/14/module_avail.snip %}
 ```
@@ -102,6 +104,7 @@ so we can use it to tell us where a particular piece of software is stored.
 {{ site.host_prompt }} which python3
 ```
 {: .bash}
+
 ```
 {% include /snippets/14/which_missing.snip %}
 ```
@@ -113,6 +116,7 @@ We can load the `python3` command with `module load`:
 {% include /snippets/14/load_python.snip %}
 ```
 {: .bash}
+
 ```
 {% include /snippets/14/which_python.snip %}
 ```
@@ -130,6 +134,7 @@ variables we can print it out using `echo`.
 {{ site.host_prompt }} echo $PATH
 ```
 {: .bash}
+
 ```
 {% include /snippets/14/path.snip %}
 ```
@@ -143,6 +148,7 @@ it added a directory to the beginning of our `$PATH`. Let's examine what's there
 {% include /snippets/14/ls_dir.snip %}
 ```
 {: .bash}
+
 ```
 {% include /snippets/14/ls_dir_output.snip %}
 ```
@@ -168,6 +174,7 @@ Let's examine the output of `module avail` more closely.
 {{ site.host_prompt }} module avail
 ```
 {: .bash}
+
 ```
 {% include /snippets/14/module_avail.snip %}
 ```
@@ -211,7 +218,8 @@ source code from GitHub using `git`.
 ```
 {{ site.host_prompt }} git clone https://github.com/lh3/seqtk.git
 ```
-{: .bash}
+{:.bash}
+
 ```
 Cloning into 'seqtk'...
 remote: Counting objects: 316, done.
@@ -219,7 +227,7 @@ remote: Total 316 (delta 0), reused 0 (delta 0), pack-reused 316
 Receiving objects: 100% (316/316), 141.52 KiB | 0 bytes/s, done.
 Resolving deltas: 100% (181/181), done.
 ```
-{: .output}
+{:.output}
 
 Now, using the instructions in the README.md file, all we need to do to complete the install is to
 `cd` into the seqtk folder and run the command `make`.
@@ -228,7 +236,8 @@ Now, using the instructions in the README.md file, all we need to do to complete
 {{ site.host_prompt }} cd seqtk
 {{ site.host_prompt }} make
 ```
-{: .bash}
+{:.bash}
+
 ```
 gcc -g -Wall -O2 -Wno-unused-function seqtk.c -o seqtk -lz -lm
 seqtk.c: In function ‘stk_comp’:
@@ -236,14 +245,15 @@ seqtk.c:399:16: warning: variable ‘lc’ set but not used [-Wunused-but-set-va
     int la, lb, lc, na, nb, nc, cnt[11];
                 ^
 ```
-{: .output}
+{:.output}
 
 It's done! Now all we need to do to use the program is invoke it like any other program.
 
 ```
 {{ site.host_prompt }} ./seqtk
 ```
-{: .bash}
+{:.bash}
+
 ```
 Usage:   seqtk <command> <arguments>
 Version: 1.2-r101-dirty
@@ -267,7 +277,7 @@ Command: seq       common transformation of FASTA/Q
          cutN      cut sequence at long N
          listhet   extract the position of each het
 ```
-{: .output}
+{:.output}
 
 We've successfully installed our first piece of software!
 

--- a/_episodes/15-transferring-files.md
+++ b/_episodes/15-transferring-files.md
@@ -28,7 +28,7 @@ lesson sample files using the following command:
 ```
 {{ site.host_prompt }} wget {{ site.url }}{{ site.baseurl }}/files/bash-lesson.tar.gz
 ```
-{: .bash}
+{:.bash}
 
 ## Transferring single files and folders with scp
 
@@ -39,13 +39,13 @@ To transfer *to* another computer:
 ```
 {{ site.local_prompt }} scp /path/to/local/file.txt yourUsername@remote.computer.address:/path/on/remote/computer
 ```
-{: .bash}
+{:.bash}
 
 To download *from* another computer:
 ```
 {{ site.local_prompt }} scp yourUsername@remote.computer.address:/path/on/remote/computer/file.txt /path/to/local/
 ```
-{: .bash}
+{:.bash}
 
 Note that we can simplify doing this by shortening our paths. On the remote computer, everything
 after the `:` is relative to our home directory. We can simply just add a `:` and leave it at that
@@ -54,16 +54,16 @@ if we don't care where the file goes.
 ```
 {{ site.local_prompt }} scp local-file.txt yourUsername@remote.computer.address:
 ```
-{: .bash}
+{:.bash}
 
 To recursively copy a directory, we just add the `-r` (recursive) flag:
 
 ```
 {{ site.local_prompt }} scp -r some-local-folder/ yourUsername@remote.computer.address:target-directory/
 ```
-{: .bash}
+{:.bash}
 
-> ## A note on rsync
+> ## A note on `rsync`
 >
 > As you gain experience with transferring files, you may find the `scp` command limiting. The
 > [rsync](https://rsync.samba.org/) utility provides advanced features for file transfer and is
@@ -71,10 +71,11 @@ To recursively copy a directory, we just add the `-r` (recursive) flag:
 > transferring large and/or many files and creating synced backup folders.
 >
 > The syntax is similar to `scp`. To transfer *to* another computer with commonly used options:
+>
 > ```
 > [local]$ rsync -avzP /path/to/local/file.txt yourUsername@remote.computer.address:/path/on/remote/computer
 > ```
-> {: .bash}
+> {:.bash}
 >
 > The `a` (archive) option preserves file timestamps and permissions among other things; the `v` (verbose)
 > option gives verbose output to help monitor the transfer; the `z` (compression) option compresses
@@ -83,25 +84,28 @@ To recursively copy a directory, we just add the `-r` (recursive) flag:
 > of the transfer.
 >
 > To recursively copy a directory, we can use the same options:
+>
 > ```
 > [local]$ rsync -avzP /path/to/local/dir yourUsername@remote.computer.address:/path/on/remote/computer
 > ```
-> {: .bash}
+> {:.bash}
 > 
 > The `a` (archive) option implies recursion.
 > 
 > To download a file, we simply change the source and destination:
+>
 > ```
 > [local]$ rsync -avzP yourUsername@remote.computer.address:/path/on/remote/computer/file.txt /path/to/local/
 > ```
-> {: .bash}
-{: .callout}
+> {:.bash}
+{:.callout}
 
 ## Transferring files interactively with FileZilla (sftp)
 
 FileZilla is a cross-platform client for downloading and uploading files to and from a remote
-computer. It is absolutely fool-proof and always works quite well. It uses the `sftp`
-protocol. You can read more about using the `sftp` protocol in the command line [here]({{ site.baseurl }}{% link _extras/discuss.md %}).
+computer. It is absolutely fool-proof and always works quite well. It uses the `sftp` protocol. You
+can read more about using the `sftp` protocol in the command line [here]({{ site.baseurl }}{% link
+_extras/discuss.md %}).
 
 Download and install the FileZilla client from
 [https://filezilla-project.org](https://filezilla-project.org). After installing and opening the
@@ -139,7 +143,7 @@ all files contained inside `output_data` into an archive file called `output_dat
 ```
 {{ site.local_prompt }} tar -cvf output_data.tar output_data/
 ```
-{: .bash}
+{:.bash}
 
 The options we used for `tar` are:
 
@@ -147,15 +151,17 @@ The options we used for `tar` are:
 - `-v` - Verbose (print what you are doing!)
 - `-f mydata.tar` - Create the archive in file *output_data.tar*
 
-The tar command allows users to concatenate flags. Instead of typing `tar -c -v -f`, we can use `tar -cvf`. We can also use the `tar` command to extract the files from the archive once we have transferred it:
+The tar command allows users to concatenate flags. Instead of typing `tar -c -v -f`, we can use `tar
+-cvf`. We can also use the `tar` command to extract the files from the archive once we have
+transferred it:
 
 ```
 {{ site.local_prompt }} tar -xvf output_data.tar
 ```
-{: .bash}
+{:.bash}
 
-This will put the data into a directory called `output_data`. Be careful, it will overwrite data there if this
-directory already exists!
+This will put the data into a directory called `output_data`. Be careful, it will overwrite data
+there if this directory already exists!
 
 Sometimes you may also want to compress the archive to save space and speed up the transfer. However,
 you should be aware that for large amounts of data compressing and un-compressing can take longer
@@ -166,7 +172,7 @@ it is compressed, e.g.:
 ```
 {{ site.local_prompt }} tar -czvf output_data.tar.gz output_data/
 ```
-{: .bash}
+{:.bash}
 
 The `tar` command is used to extract the files from the archive in exactly the same way as for
 uncompressed data as `tar` recognizes it is compressed and un-compresses and extracts at the 
@@ -175,13 +181,13 @@ same time:
 ```
 {{ site.local_prompt }} tar -xvf output_data.tar.gz
 ```
-{: .bash}
+{:.bash}
 
 > ## Transferring files
 >
 > Using one of the above methods, try transferring files to and from the cluster. Which method do
 > you like the best?
-{: .challenge}
+{:.challenge}
 
 > ## Working with Windows
 >
@@ -202,7 +208,7 @@ same time:
 > 
 > To convert the file, just run `dos2unix filename`. (Conversely, to convert back to Windows format,
 > you can run `unix2dos filename`.)
-{: .callout}
+{:.callout}
 
 > ## A note on ports
 >
@@ -210,6 +216,6 @@ same time:
 > same connection method used by SSH. In fact, all file transfers using these methods occur through
 > an SSH connection. If you can connect via SSH over the normal port, you will be able to transfer
 > files.
-{: .callout}
+{:.callout}
 
 {% include links.md %}

--- a/_episodes/16-resources.md
+++ b/_episodes/16-resources.md
@@ -36,18 +36,19 @@ waiting to match what you asked for.
 
 {% include /snippets/16/bench.snip %}
 
-Once the job completes (note that it takes much less time than expected), we can query the 
-scheduler to see how long our job took and what resources were used. We will use `{{ site.sched_hist }}` to
+Once the job completes (note that it takes much less time than expected), we can query the scheduler
+to see how long our job took and what resources were used. We will use `{{ site.sched_hist }}` to
 get statistics about our job.
 
 ```
 {{ site.host_prompt }} {{ site.sched_hist }}
 ```
-{: .bash}
+{:.bash}
+
 ```
 {% include /snippets/16/stat_output.snip %}
 ```
-{: .output}
+{:.output}
 
 This shows all the jobs we ran recently (note that there are multiple entries per job). To get
 detailed info about a job, we change command slightly.
@@ -55,7 +56,7 @@ detailed info about a job, we change command slightly.
 ```
 {{ site.host_prompt }} {{ site.sched_hist }} {{ site.sched_flag_histdetail }} 1965
 ```
-{: .bash}
+{:.bash}
 
 It will show a lot of info, in fact, every single piece of info collected on your job by the
 scheduler. It may be useful to redirect this information to `less` to make it easier to view (use
@@ -64,7 +65,7 @@ the left and right arrow keys to scroll through fields).
 ```
 {{ site.host_prompt }} {{ site.sched_hist }} {{ site.sched_flag_histdetail }} 1965| less
 ```
-{: .bash}
+{:.bash}
 
 Some interesting fields include the following:
 
@@ -78,17 +79,18 @@ Some interesting fields include the following:
 ## Measuring the statistics of currently running tasks
 
 > ## Connecting to Nodes
+>
 > Typically, clusters allow users to connect directly to compute nodes from the head 
 > node. This is useful to check on a running job and see how it's doing, but is not
 > a recommended practice in general, because it bypasses the resource manager.
 > If you need to do this, check where a job is running with `{{ site.sched_status }}`, then
 > run `ssh nodename`. (Note, this may not work on all clusters.)
-{: .callout}
+{:.callout}
   
 We can also check on stuff running on the login node right now the same way (so it's 
 not necessary to `ssh` to a node for this example).
 
-### top
+### `top`
 
 The best way to check current system stats is with `top` (`htop` is a prettier version of `top` but
 may not be available on your system).
@@ -98,11 +100,12 @@ Some sample output might look like the following (`Ctrl + c` to exit):
 ```
 {{ site.host_prompt }} top
 ```
-{: .bash}
+{:.bash}
+
 ```
 {% include /snippets/16/top_output.snip %}
 ```
-{: .output}
+{:.output}
 
 Overview of the most important fields:
 
@@ -116,7 +119,7 @@ Overview of the most important fields:
   twice the normal rate.
 * `COMMAND` - What command was used to launch a process?
 
-### free
+### `free`
 
 Another useful tool is the `free -h` command. This will show the currently used/free amount of
 memory.
@@ -124,11 +127,12 @@ memory.
 ```
 {{ site.host_prompt }} free -h
 ```
-{: .bash}
+{:.bash}
+
 ```
 {% include /snippets/16/free_output.snip %}
 ```
-{: .output}
+{:.output}
 
 The key fields here are total, used, and available - which represent the amount of memory that the
 machine has in total, how much is currently being used, and how much is still available. When a
@@ -144,13 +148,14 @@ To show all processes from your current session, type `ps`.
 ```
 {{ site.host_prompt }} ps
 ```
-{: .bash}
+{:.bash}
+
 ```
   PID TTY          TIME CMD
 15113 pts/5    00:00:00 bash
 15218 pts/5    00:00:00 ps
 ```
-{: .output}
+{:.output}
 
 Note that this will only show processes from our current session. To show all processes you own
 (regardless of whether they are part of your current session or not), you can use `ps ux`.
@@ -158,14 +163,15 @@ Note that this will only show processes from our current session. To show all pr
 ```
 {{ site.host_prompt }} ps ux
 ```
-{: .bash}
+{:.bash}
+
 ```
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 auser  67780  0.0  0.0 149140  1724 pts/81   R+   13:51   0:00 ps ux
 auser  73083  0.0  0.0 142392  2136 ?        S    12:50   0:00 sshd: auser@pts/81
 auser  73087  0.0  0.0 114636  3312 pts/81   Ss   12:50   0:00 -bash
 ```
-{: .output}
+{:.output}
 
 This is useful for identifying which processes are doing what.
 

--- a/_episodes/17-responsiblity.md
+++ b/_episodes/17-responsiblity.md
@@ -46,7 +46,7 @@ login sessions will start to run slowly and may even freeze or hang.
 > issues for other people. Think carefully about the potential implications of issuing
 > commands that may use large amounts of resource.
 >
-{: .callout}
+{:.callout}
 
 You can always use the commands `top` and `ps ux` to list the processes you are running on a login
 node and the amount of CPU and memory they are using. The `kill` command can be used along
@@ -61,7 +61,7 @@ with the *PID* to terminate any processes that are using large amounts of resour
 > molecular_dynamics_2
 > tar -xzf R-3.3.0.tar.gz
 > 
-{: .challenge}
+{:.challenge}
 
 If you experience performance issues with a login node you should report it to the system
 staff (usually via the helpdesk) for them to investigate. You can use the `top` command
@@ -84,12 +84,13 @@ systems provide dedicated resources for testing that have short wait times to he
 avoid this issue.
 
 > ## Test job submission scripts that use large amounts of resource
+>
 > Before submitting a large run of jobs, submit one as a test first to make sure everything works
 > as expected.
 >
 > Before submitting a very large or very long job submit a short truncated test to ensure that
 > the job starts as expected
-{: .callout}
+{:.callout}
 
 ## Have a backup plan
 
@@ -117,11 +118,12 @@ In all these cases, the helpdesk of the system you are using should be able to p
 guidance on your options for data transfer for the volumes of data you will be using.
 
 > ## Your data is your responsibility
+>
 > Make sure you understand what the backup policy is on the file systems on the system you are
 > using and what implications this has for your work if you lose your data on the system. Plan
 > your backups of critical data and how you will transfer data off the system throughout the
 > project.
-{: .callout}
+{:.callout}
 
 ## Transferring data
 
@@ -161,13 +163,13 @@ be created using tools like `tar` and `zip`. We have already met `tar` when we t
 transfer earlier. 
 
 > ## Consider the best way to transfer data
+>
 > If you are transferring large amounts of data you will need to think about what may affect your transfer
 > performance. It is always useful to run some tests that you can use to extrapolate how long it will
 > take to transfer your data.
 >
 > If you have many files, it is best to combine them into an archive file before you transfer them using a
 > tool such as `tar`.
-{: .callout}
-
+{:.callout}
 
 {% include links.md %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -11,7 +11,7 @@ downloading and uploading files. Let's connect to a cluster, using `sftp`- you'l
 the same way as SSH:
 
 ```
-sftp yourUsername@remote.computer.address
+{{ site.local_prompt }} sftp yourUsername@remote.computer.address
 ```
 {: .bash}
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -14,7 +14,7 @@
       {% comment %} Select what logo to display. {% endcomment %}
       {% if site.carpentry == "swc" %}
       <a href="{{ site.swc_site }}" class="pull-left">
-        <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/swc-icon-blue.svg %}" alt="Software Carpentry logo" />
+        <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/hpc-icon-blue.svg %}" alt="Software Carpentry logo" />
       </a>
       {% elsif site.carpentry == "dc" %}
       <a href="{{ site.dc_site }}" class="pull-left">

--- a/_includes/snippets/16/bench.snip
+++ b/_includes/snippets/16/bench.snip
@@ -3,7 +3,7 @@
 > Create a job that runs the following command in the same directory as `.fastq` files
 > 
 > ```
-> fastqc name_of_fastq_file
+> {{site.host_prompt }} fastqc name_of_fastq_file
 > ```
 > {: .bash}
 > 

--- a/assets/img/hpc-icon-blue.svg
+++ b/assets/img/hpc-icon-blue.svg
@@ -1,0 +1,700 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:ooo="http://xml.openoffice.org/svg/export"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.2"
+   width="30.48mm"
+   height="23.11mm"
+   viewBox="0 0 3048 2311"
+   preserveAspectRatio="xMidYMid"
+   fill-rule="evenodd"
+   stroke-width="28.222"
+   stroke-linejoin="round"
+   xml:space="preserve"
+   id="svg188"
+   sodipodi:docname="hpc-carpentry.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:export-filename="/Valhalla/repositories/carpentries/hpc-intro/fig/hpc-carpentry.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"><metadata
+   id="metadata192"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1916"
+   inkscape:window-height="1022"
+   id="namedview190"
+   showgrid="false"
+   inkscape:zoom="4.6992677"
+   inkscape:cx="125.38507"
+   inkscape:cy="31.787368"
+   inkscape:window-x="0"
+   inkscape:window-y="28"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg188" />
+ <defs
+   class="ClipPathGroup"
+   id="defs124">
+  <clipPath
+   id="presentation_clip_path"
+   clipPathUnits="userSpaceOnUse">
+   <rect
+   x="0"
+   y="0"
+   width="3048"
+   height="2311"
+   id="rect121" />
+  </clipPath>
+ <inkscape:path-effect
+   is_visible="true"
+   id="path-effect7350"
+   effect="spiro" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7254"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7258"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7262"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7266"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7270"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7274"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7278"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7282"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7369"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7371"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7373"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7375"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7377"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7379"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7381"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7383"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7385"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7387"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7389"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7391"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7393"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7395"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7397"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7399"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7401"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7403"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7405"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7407"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7409"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7411"
+   is_visible="true" /><inkscape:path-effect
+   is_visible="true"
+   id="path-effect7413"
+   effect="spiro" /><inkscape:path-effect
+   effect="spiro"
+   id="path-effect7415"
+   is_visible="true" /></defs>
+ <defs
+   class="TextShapeIndex"
+   id="defs128">
+  <g
+   ooo:slide="id1"
+   ooo:id-list="id3 id4 id5"
+   id="g126" />
+ </defs>
+ <defs
+   class="EmbeddedBulletChars"
+   id="defs157">
+  <g
+   id="bullet-char-template(57356)"
+   transform="scale(0.00048828125,-0.00048828125)">
+   <path
+   d="M 580,1141 L 1163,571 580,0 -4,571 580,1141 Z"
+   id="path130" />
+  </g>
+  <g
+   id="bullet-char-template(57354)"
+   transform="scale(0.00048828125,-0.00048828125)">
+   <path
+   d="M 8,1128 L 1137,1128 1137,0 8,0 8,1128 Z"
+   id="path133" />
+  </g>
+  <g
+   id="bullet-char-template(10146)"
+   transform="scale(0.00048828125,-0.00048828125)">
+   <path
+   d="M 174,0 L 602,739 174,1481 1456,739 174,0 Z M 1358,739 L 309,1346 659,739 1358,739 Z"
+   id="path136" />
+  </g>
+  <g
+   id="bullet-char-template(10132)"
+   transform="scale(0.00048828125,-0.00048828125)">
+   <path
+   d="M 2015,739 L 1276,0 717,0 1260,543 174,543 174,936 1260,936 717,1481 1274,1481 2015,739 Z"
+   id="path139" />
+  </g>
+  <g
+   id="bullet-char-template(10007)"
+   transform="scale(0.00048828125,-0.00048828125)">
+   <path
+   d="M 0,-2 C -7,14 -16,27 -25,37 L 356,567 C 262,823 215,952 215,954 215,979 228,992 255,992 264,992 276,990 289,987 310,991 331,999 354,1012 L 381,999 492,748 772,1049 836,1024 860,1049 C 881,1039 901,1025 922,1006 886,937 835,863 770,784 769,783 710,716 594,584 L 774,223 C 774,196 753,168 711,139 L 727,119 C 717,90 699,76 672,76 641,76 570,178 457,381 L 164,-76 C 142,-110 111,-127 72,-127 30,-127 9,-110 8,-76 1,-67 -2,-52 -2,-32 -2,-23 -1,-13 0,-2 Z"
+   id="path142" />
+  </g>
+  <g
+   id="bullet-char-template(10004)"
+   transform="scale(0.00048828125,-0.00048828125)">
+   <path
+   d="M 285,-33 C 182,-33 111,30 74,156 52,228 41,333 41,471 41,549 55,616 82,672 116,743 169,778 240,778 293,778 328,747 346,684 L 369,508 C 377,444 397,411 428,410 L 1163,1116 C 1174,1127 1196,1133 1229,1133 1271,1133 1292,1118 1292,1087 L 1292,965 C 1292,929 1282,901 1262,881 L 442,47 C 390,-6 338,-33 285,-33 Z"
+   id="path145" />
+  </g>
+  <g
+   id="bullet-char-template(9679)"
+   transform="scale(0.00048828125,-0.00048828125)">
+   <path
+   d="M 813,0 C 632,0 489,54 383,161 276,268 223,411 223,592 223,773 276,916 383,1023 489,1130 632,1184 813,1184 992,1184 1136,1130 1245,1023 1353,916 1407,772 1407,592 1407,412 1353,268 1245,161 1136,54 992,0 813,0 Z"
+   id="path148" />
+  </g>
+  <g
+   id="bullet-char-template(8226)"
+   transform="scale(0.00048828125,-0.00048828125)">
+   <path
+   d="M 346,457 C 273,457 209,483 155,535 101,586 74,649 74,723 74,796 101,859 155,911 209,963 273,989 346,989 419,989 480,963 531,910 582,859 608,796 608,723 608,648 583,586 532,535 482,483 420,457 346,457 Z"
+   id="path151" />
+  </g>
+  <g
+   id="bullet-char-template(8211)"
+   transform="scale(0.00048828125,-0.00048828125)">
+   <path
+   d="M -4,459 L 1135,459 1135,606 -4,606 -4,459 Z"
+   id="path154" />
+  </g>
+ </defs>
+ <defs
+   class="TextEmbeddedBitmaps"
+   id="defs159" />
+ <g
+   id="g164">
+  <g
+   id="id2"
+   class="Master_Slide">
+   <g
+   id="bg-id2"
+   class="Background" />
+   <g
+   id="bo-id2"
+   class="BackgroundObjects" />
+  </g>
+ </g>
+ <g
+   class="SlideGroup"
+   id="g186"
+   transform="translate(105.83333)">
+  <g
+   id="g184"
+   style="fill:#2b3990;fill-opacity:1">
+   <g
+   id="id1"
+   class="Slide"
+   clip-path="url(#presentation_clip_path)"
+   style="fill:#2b3990;fill-opacity:1">
+    <g
+   class="Page"
+   id="g181"
+   style="fill:#2b3990;fill-opacity:1">
+     <g
+   class="com.sun.star.drawing.ClosedBezierShape"
+   id="g169"
+   style="fill:#2b3990;fill-opacity:1">
+      <g
+   id="id3"
+   style="fill:#2b3990;fill-opacity:1">
+       <path
+   d="m 2920,575 c -40,-43 -239,-38 -294,-39 -302,-2 -866,15 -1149,15 -11,0 -50,19 -44,35 -200,0 -306,1 -548,-2 C 754,583 442,599 434,368 430,252 536,150 661,26 581,2 501,55 420,100 381,139 354,165 321,198 199,376 151,556 180,737 290,716 372,867 295,938 l -69,1 c -33,0 -59,34 -58,74 l 2,160 c 1,41 28,68 60,68 h 348 c 32,-1 58,-34 57,-75 l -2,-160 c 0,-40 -27,-73 -60,-72 H 530 C 453,719 700,747 840,749 c 262,2 350,1 581,1 13,16 7,46 43,61 23,9 1413,6 1438,0 25,-6 18,-18 27,-27 12,-48 39,-156 -9,-209 z M 576,964 v 170 c 0,0 -5,-111 -50,-118 -46,-7 -20,-52 -20,-52 z M 2905,651 c 0,0 -41,-14 -74,-35 -71,-46 -1332,-5 -1332,-5 l 36,-30 c 0,0 1285,-22 1329,0 44,22 41,70 41,70 z"
+   id="path166"
+   inkscape:connector-curvature="0"
+   style="fill:#2b3990;stroke:none;fill-opacity:1" />
+      </g>
+     </g>
+     <g
+   class="com.sun.star.drawing.ClosedBezierShape"
+   id="g174"
+   style="fill:#2b3990;fill-opacity:1">
+      <g
+   id="id4"
+   style="fill:#2b3990;fill-opacity:1">
+       
+      </g>
+     </g>
+     <g
+   class="com.sun.star.drawing.ClosedBezierShape"
+   id="g179"
+   style="fill:#2b3990;fill-opacity:1">
+      <g
+   id="id5"
+   style="fill:#2b3990;fill-opacity:1">
+       
+      </g>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+<g
+   transform="matrix(8.4666663,0,0,8.4666663,671.2609,46.19486)"
+   id="layer1"
+   inkscape:label="Ebene 1"><g
+     id="g7284"
+     transform="translate(-223.92062,-976.97751)"><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 164.83025,1163.0785 -19.99998,10e-5"
+       id="path7252"
+       inkscape:path-effect="#path-effect7254"
+       inkscape:original-d="m 164.83025,1163.0785 -19.99998,10e-5"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83024,1212.3866 H 144.83026"
+       inkscape:path-effect="#path-effect7258"
+       id="path7256"
+       d="M 164.83024,1212.3866 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83024,1205.3426 H 144.83026"
+       id="path7260"
+       inkscape:path-effect="#path-effect7262"
+       inkscape:original-d="M 164.83024,1205.3426 H 144.83026"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="m 164.83025,1198.2985 -19.99998,10e-5"
+       inkscape:path-effect="#path-effect7266"
+       id="path7264"
+       d="m 164.83025,1198.2985 -19.99998,10e-5"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83023,1191.2546 H 144.83026"
+       id="path7268"
+       inkscape:path-effect="#path-effect7270"
+       inkscape:original-d="M 164.83023,1191.2546 H 144.83026"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83023,1184.2106 H 144.83026"
+       inkscape:path-effect="#path-effect7274"
+       id="path7272"
+       d="M 164.83023,1184.2106 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83024,1177.1666 H 144.83026"
+       id="path7276"
+       inkscape:path-effect="#path-effect7278"
+       inkscape:original-d="M 164.83024,1177.1666 H 144.83026"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83031,1170.1226 H 144.83026"
+       inkscape:path-effect="#path-effect7282"
+       id="path7280"
+       d="M 164.83031,1170.1226 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /></g><g
+     transform="translate(-125.73995,-976.97751)"
+     id="g7294"><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="m 164.83025,1163.0785 -19.99998,10e-5"
+       inkscape:path-effect="#path-effect7254"
+       id="path7296"
+       d="m 164.83025,1163.0785 -19.99998,10e-5"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83024,1212.3866 H 144.83026"
+       id="path7298"
+       inkscape:path-effect="#path-effect7258"
+       inkscape:original-d="M 164.83024,1212.3866 H 144.83026"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83024,1205.3426 H 144.83026"
+       inkscape:path-effect="#path-effect7262"
+       id="path7300"
+       d="M 164.83024,1205.3426 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 164.83025,1198.2985 -19.99998,10e-5"
+       id="path7302"
+       inkscape:path-effect="#path-effect7266"
+       inkscape:original-d="m 164.83025,1198.2985 -19.99998,10e-5"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83023,1191.2546 H 144.83026"
+       inkscape:path-effect="#path-effect7270"
+       id="path7304"
+       d="M 164.83023,1191.2546 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83023,1184.2106 H 144.83026"
+       id="path7306"
+       inkscape:path-effect="#path-effect7274"
+       inkscape:original-d="M 164.83023,1184.2106 H 144.83026"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83024,1177.1666 H 144.83026"
+       inkscape:path-effect="#path-effect7278"
+       id="path7308"
+       d="M 164.83024,1177.1666 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83031,1170.1226 H 144.83026"
+       id="path7310"
+       inkscape:path-effect="#path-effect7282"
+       inkscape:original-d="M 164.83031,1170.1226 H 144.83026"
+       inkscape:connector-curvature="0" /></g><g
+     id="g7312"
+     transform="rotate(90,531.34189,635.12381)"><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 164.83025,1163.0785 -19.99998,10e-5"
+       id="path7314"
+       inkscape:path-effect="#path-effect7254"
+       inkscape:original-d="m 164.83025,1163.0785 -19.99998,10e-5"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83024,1212.3866 H 144.83026"
+       inkscape:path-effect="#path-effect7258"
+       id="path7316"
+       d="M 164.83024,1212.3866 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83024,1205.3426 H 144.83026"
+       id="path7318"
+       inkscape:path-effect="#path-effect7262"
+       inkscape:original-d="M 164.83024,1205.3426 H 144.83026"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="m 164.83025,1198.2985 -19.99998,10e-5"
+       inkscape:path-effect="#path-effect7266"
+       id="path7320"
+       d="m 164.83025,1198.2985 -19.99998,10e-5"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83023,1191.2546 H 144.83026"
+       id="path7322"
+       inkscape:path-effect="#path-effect7270"
+       inkscape:original-d="M 164.83023,1191.2546 H 144.83026"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83023,1184.2106 H 144.83026"
+       inkscape:path-effect="#path-effect7274"
+       id="path7324"
+       d="M 164.83023,1184.2106 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83024,1177.1666 H 144.83026"
+       id="path7326"
+       inkscape:path-effect="#path-effect7278"
+       inkscape:original-d="M 164.83024,1177.1666 H 144.83026"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83031,1170.1226 H 144.83026"
+       inkscape:path-effect="#path-effect7282"
+       id="path7328"
+       d="M 164.83031,1170.1226 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /></g><g
+     transform="rotate(90,580.44903,586.01667)"
+     id="g7330"><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="m 164.83025,1163.0785 -19.99998,10e-5"
+       inkscape:path-effect="#path-effect7254"
+       id="path7332"
+       d="m 164.83025,1163.0785 -19.99998,10e-5"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83024,1212.3866 H 144.83026"
+       id="path7334"
+       inkscape:path-effect="#path-effect7258"
+       inkscape:original-d="M 164.83024,1212.3866 H 144.83026"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83024,1205.3426 H 144.83026"
+       inkscape:path-effect="#path-effect7262"
+       id="path7336"
+       d="M 164.83024,1205.3426 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 164.83025,1198.2985 -19.99998,10e-5"
+       id="path7338"
+       inkscape:path-effect="#path-effect7266"
+       inkscape:original-d="m 164.83025,1198.2985 -19.99998,10e-5"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83023,1191.2546 H 144.83026"
+       inkscape:path-effect="#path-effect7270"
+       id="path7340"
+       d="M 164.83023,1191.2546 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83023,1184.2106 H 144.83026"
+       id="path7342"
+       inkscape:path-effect="#path-effect7274"
+       inkscape:original-d="M 164.83023,1184.2106 H 144.83026"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       inkscape:original-d="M 164.83024,1177.1666 H 144.83026"
+       inkscape:path-effect="#path-effect7278"
+       id="path7344"
+       d="M 164.83024,1177.1666 H 144.83026"
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#9e9e9e;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 164.83031,1170.1226 H 144.83026"
+       id="path7346"
+       inkscape:path-effect="#path-effect7282"
+       inkscape:original-d="M 164.83031,1170.1226 H 144.83026"
+       inkscape:connector-curvature="0" /></g><path
+     inkscape:connector-curvature="0"
+     inkscape:original-d="m -57.365933,168.36522 -3.74414,3.7441 v 78.6582 h 82.40039 v -82.4062 z"
+     inkscape:path-effect="#path-effect7350"
+     id="path7348"
+     d="m -57.365933,168.36522 -3.74414,3.7441 v 78.6582 h 82.40039 v -82.4062 z"
+     style="fill:#424242;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" /></g><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:4.24661207"
+   d="M 5.9140542,69.365913 V 56.832064 L 6.4846674,56.274875 7.0552805,55.717687 H 19.575705 32.096129 V 68.808724 81.899762 H 19.005092 5.9140542 Z m 3.2205716,-9.907174 c 0.7102429,-0.323609 0.7768938,-1.417202 0.1081856,-1.775084 -0.4530271,-0.242452 -0.7901,-0.194577 -1.1748374,0.166865 -0.6569218,0.617146 -0.3438522,1.456253 0.6603444,1.769893 0.016796,0.0052 0.1996341,-0.06751 0.4063074,-0.161674 z"
+   id="path4161"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:4.24661207"
+   d="m 10.277733,52.783489 v -2.783727 h 0.37618 0.376179 v 2.783727 2.783726 h -0.376179 -0.37618 z"
+   id="path4163"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:4.24661207"
+   d="M 0.19612977,61.285139 V 60.833724 H 2.9798562 5.7635825 v 0.451415 0.451415 H 2.9798562 0.19612977 Z"
+   id="path4165"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:4.24661207"
+   d="M 0.19612977,63.542215 V 63.0908 H 2.9798562 5.7635825 v 0.451415 0.451415 H 2.9798562 0.19612977 Z"
+   id="path4167"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:4.24661207"
+   d="M 0.19612977,65.79929 V 65.347875 H 2.9798562 5.7635825 v 0.451415 0.451415 H 2.9798562 0.19612977 Z"
+   id="path4171"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:4.24661207"
+   d="M 0.19612977,68.056366 V 67.604951 H 2.9798562 5.7635825 v 0.451415 0.451415 H 2.9798562 0.19612977 Z"
+   id="path4173"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:4.24661207"
+   d="M 0.19612977,70.313441 V 69.862026 H 2.9798562 5.7635825 v 0.451415 0.451415 H 2.9798562 0.19612977 Z"
+   id="path4175"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="M 0.11599994,72.580325 V 72.101527 H 2.9355882 5.7551765 v 0.478798 0.478798 H 2.9355882 0.11599994 Z"
+   id="path4177"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="M 0.11599994,74.814716 V 74.335918 H 2.9355882 5.7551765 v 0.478798 0.478798 H 2.9355882 0.11599994 Z"
+   id="path4179"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="M 0.11599994,77.102306 V 76.676708 H 2.9355882 5.7551765 v 0.425598 0.425598 H 2.9355882 0.11599994 Z"
+   id="path4181"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 10.223958,84.816274 v -2.819588 h 0.425598 0.425598 v 2.819588 2.819588 h -0.425598 -0.425598 z"
+   id="path4183"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 12.458349,84.816274 v -2.819588 h 0.478798 0.478798 v 2.819588 2.819588 h -0.478798 -0.478798 z"
+   id="path4185"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 14.799139,84.816274 v -2.819588 h 0.425598 0.425598 v 2.819588 2.819588 h -0.425598 -0.425598 z"
+   id="path4187"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 17.03353,84.816274 v -2.819588 h 0.425598 0.425598 v 2.819588 2.819588 H 17.459128 17.03353 Z"
+   id="path4189"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 19.26792,84.816274 v -2.819588 h 0.425598 0.425599 v 2.819588 2.819588 H 19.693518 19.26792 Z"
+   id="path4191"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 21.502311,84.816274 v -2.819588 h 0.425598 0.425598 v 2.819588 2.819588 h -0.425598 -0.425598 z"
+   id="path4193"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 23.736702,84.816274 v -2.819588 h 0.425598 0.425598 v 2.819588 2.819588 H 24.1623 23.736702 Z"
+   id="path4195"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 25.971092,84.816274 v -2.819588 h 0.478798 0.478798 v 2.819588 2.819588 H 26.44989 25.971092 Z"
+   id="path4197"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 32.248666,77.102306 v -0.425598 h 2.819588 2.819589 v 0.425598 0.425598 h -2.819589 -2.819588 z"
+   id="path4199"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 32.248666,74.812949 v -0.480564 l 2.792989,0.02837 2.792988,0.02837 0.03272,0.452198 0.03272,0.452198 h -2.825706 -2.825706 z"
+   id="path4201"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 32.248666,72.582092 v -0.480565 h 2.825706 2.825706 l -0.03272,0.452198 -0.03272,0.452198 -2.792988,0.02837 -2.792989,0.02837 z"
+   id="path4203"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 32.248666,70.292735 v -0.425599 h 2.819588 2.819589 v 0.425599 0.425598 h -2.819589 -2.819588 z"
+   id="path4205"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 32.248666,68.058344 v -0.425598 h 2.819588 2.819589 v 0.425598 0.425598 h -2.819589 -2.819588 z"
+   id="path4207"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 32.248666,65.823953 v -0.425598 h 2.819588 2.819589 v 0.425598 0.425598 h -2.819589 -2.819588 z"
+   id="path4209"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 32.248666,63.589563 v -0.425599 h 2.819588 2.819589 v 0.425599 0.425598 h -2.819589 -2.819588 z"
+   id="path4211"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 32.248666,61.303739 v -0.480565 h 2.825706 2.825706 l -0.03272,0.452198 -0.03272,0.452198 -2.792988,0.02837 -2.792989,0.02837 z"
+   id="path4213"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="M 25.971092,52.736808 V 49.86402 h 0.478798 0.478798 v 2.872788 2.872788 H 26.44989 25.971092 Z"
+   id="path4215"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="M 23.736702,52.736808 V 49.86402 h 0.425598 0.425598 v 2.872788 2.872788 H 24.1623 23.736702 Z"
+   id="path4217"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="M 21.502311,52.736808 V 49.86402 h 0.425598 0.425598 v 2.872788 2.872788 h -0.425598 -0.425598 z"
+   id="path4219"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="M 19.26792,52.736808 V 49.86402 h 0.425598 0.425599 v 2.872788 2.872788 H 19.693518 19.26792 Z"
+   id="path4221"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="M 17.03353,52.736808 V 49.86402 h 0.425598 0.425598 v 2.872788 2.872788 H 17.459128 17.03353 Z"
+   id="path4223"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="M 14.799139,52.736808 V 49.86402 h 0.425598 0.425598 v 2.872788 2.872788 h -0.425598 -0.425598 z"
+   id="path4225"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#2b3990;fill-opacity:1;stroke-width:3.00280833"
+   d="m 12.458349,52.73069 v -2.878906 l 0.452198,0.03272 0.452198,0.03272 0.02834,2.846189 0.02834,2.846188 h -0.480536 -0.480535 z"
+   id="path4227"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#000000;fill-opacity:0;stroke-width:3.00280833"
+   d="M 8.1907862,59.290121 C 7.5869355,58.782014 7.6620395,58.066229 8.3555518,57.719807 9.263803,57.266119 10.0878,58.397932 9.4100012,59.168161 c -0.3623774,0.411795 -0.820324,0.457604 -1.219215,0.12196 z"
+   id="path5034"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#ffffff;fill-opacity:0;stroke-width:3.00280833"
+   d="M 8.1907862,59.290121 C 7.5869355,58.782014 7.6620395,58.066229 8.3555518,57.719807 9.263803,57.266119 10.0878,58.397932 9.4100012,59.168161 c -0.3623774,0.411795 -0.820324,0.457604 -1.219215,0.12196 z"
+   id="path5036"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#ffffff;fill-opacity:0;stroke-width:1.50140417"
+   d="M 8.3146438,59.414873 C 8.1856872,59.346792 8.0092126,59.190337 7.9224779,59.067195 7.3793174,58.296041 8.3150613,57.239973 9.1595922,57.671004 c 0.2438006,0.124431 0.3557587,0.245282 0.4613497,0.497997 0.1437913,0.344141 0.071756,0.724245 -0.1947867,1.027821 -0.3078679,0.350642 -0.710682,0.429664 -1.1115114,0.218051 z"
+   id="path5038"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /><path
+   style="fill:#ffffff;fill-opacity:1;stroke-width:1.50140417"
+   d="M 8.3727761,59.454262 C 8.0353852,59.262152 7.9096849,59.131144 7.8084768,58.866134 7.5214579,58.114586 8.3802518,57.321612 9.1325816,57.643513 9.891389,57.968185 9.867699,59.089102 9.0942973,59.45498 8.7359948,59.624484 8.6716146,59.62442 8.3727761,59.454262 Z"
+   id="path5040"
+   inkscape:connector-curvature="0"
+   transform="scale(26.458333)" /></svg>

--- a/index.md
+++ b/index.md
@@ -24,6 +24,6 @@ By the end of this workshop, students will know how to:
 > ## Prerequisites
 >
 > Command line experience is necessary for this lesson. We recommend the participants to go through
-> https://swcarpentry.github.io/shell-novice/ if new to the terminal.
+> <https://swcarpentry.github.io/shell-novice/> if new to the terminal.
 {: .prereq}
 


### PR DESCRIPTION
This PR contains a collection of minor, atomic commits to the repository addressing some issues of style, look & feel.

- Apply spaces between code blocks to comply with the Markdown standard and clarify which block each syntax-highlighting tag applies to.
- Increase indent level (extra `#`) of some lesson sub-headings and exercise blocks to improve formatting and comply with CSS rules to render properly.
- Added a `.gitlab-ci` file, so that the site can be built on GitLab servers.
- I have also cobbled together an HPC Carpentry logo, which now displays on the rendered lessons. It's a hammer resting on (or smashing, depending on your perspective) a microchip.
- Modified `.travis.yml` to use Bundler (which reads `Gemfile`) to install Ruby packages, rather than the hard-coded dependencies.