### PR TITLE
Resolve vulnerability warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 ruby RUBY_VERSION
 
 # This will help ensure the proper Jekyll version is running.
-gem "jekyll", "3.4.0"
+gem "jekyll", ">= 3.6.3"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION
Dependabot [warns](https://github.com/hpc-carpentry/hpc-intro/network/alert/Gemfile/jekyll/open) that Jekyll 3.4.0 is outdated. This change sets Jekyll at a minimum of 3.6.3, but allows a newer gem to be installed if available.