### PR TITLE
Clear lesson check issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ writer, and then reviewed by the rest of the group once complete.
 
 ## Using this material
 
-1. Follow the instructions found in the [Software Carpentry example lesson source](https://github.com/carpentries/lesson-example/)
-   to create a repository for your lesson.
+1. Follow the instructions found in the [Software Carpentry example lesson source](
+   https://github.com/carpentries/lesson-example/) to create a repository for your lesson.
 2. Edit [_config.yml](_config.yml) to modify the configuration options for the HPC system you
    will be using in the section titled `Workshop specific values`. These options set such things
    as the address of the host to login to, definitions of the command prompt, scheduler names.
@@ -30,9 +30,9 @@ writer, and then reviewed by the rest of the group once complete.
    2. Code snippets are placed in subdirectories that are named according to the episode they
       appear in. For example, if the snippet is for episode 12, then it will be in a 
       subdirectory called `12`.
-   3. In the episodes source, snippets are included using [Liquid](https://shopify.github.io/liquid/)
-      scripting  `include` statements. For example, the first snippet in episode 12 is included using 
-      `{% include /snippets/12/info.snip %}`.
+   3. In the episodes source, snippets are included using [Liquid](
+      https://shopify.github.io/liquid/) scripting  `include` statements. For example, the first
+      snippet in episode 12 is included using `{% include /snippets/12/info.snip %}`.
 
 Please contribute any configurations you create for your local systems back into the 
 HPC Carpentry snippets library.
@@ -53,9 +53,10 @@ Software Carpentry lessons are generally episodic, with one clear concept for ea
 An episode is just a markdown file that lives under the `_episodes` folder. Here is a link to a
 [markdown cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) with most
 markdown syntax. Additionally, the Software Carpentry lesson template uses several extra bits of
-formatting- see here for a [full guide](https://carpentries.github.io/lesson-example/04-formatting/index.html).
-The most significant change is the addition of a YAML header that adds metadata (key questions,
-lesson teaching times, etc.) and special syntax for code blocks, exercises, and the like.
+formatting- see here for a [full guide](
+https://carpentries.github.io/lesson-example/04-formatting/index.html). The most significant change
+is the addition of a YAML header that adds metadata (key questions, lesson teaching times, etc.)
+and special syntax for code blocks, exercises, and the like.
 
 Episode names should be prefixed with a number of their section plus the number of their episode
 within that section. This is important because the Software Carpentry lesson template will auto-post

--- a/_episodes/11-hpc-intro.md
+++ b/_episodes/11-hpc-intro.md
@@ -46,7 +46,7 @@ In all these cases, what is needed is access to more computers than can be used 
 ## A standard Laptop for standard tasks
 
 Today, people coding or analysing data typically work with laptops.
- 
+
 {% include figure.html url="" max-width="20%" file="/fig/200px-laptop-openclipartorg-aoguerrero.svg"
  alt="A standard laptop" caption="" %}
 

--- a/_episodes/12-cluster.md
+++ b/_episodes/12-cluster.md
@@ -32,16 +32,17 @@ shared storage, providing webservices (such as e-mail or social media platforms)
 traditional compute intensive tasks such as running a simulation.
 
 The term *HPC system*, on the other hand, describes a stand-alone resource for computationally
-intensive workloads. They are typically comprised of a multitude of independent processing and storage
-elements, designed to handle high volumes of data and/or large numbers of floating-point operations
-([FLOPS](https://en.wikipedia.org/wiki/FLOPS)) with the highest possible performance. For example, all
-of the machines on the [Top-500](https://www.top500.org) list are HPC systems. To support these constraints,
-an HPC resource must exist in a specific, fixed location: networking cables can only stretch so far, and
-electrical and optical signals can travel only so fast.
+intensive workloads. They are typically comprised of a multitude of independent processing and
+storage elements, designed to handle high volumes of data and/or large numbers of floating-point
+operations ([FLOPS](https://en.wikipedia.org/wiki/FLOPS)) with the highest possible performance.
+For example, all of the machines on the [Top-500](https://www.top500.org) list are HPC systems. To
+support these constraints, an HPC resource must exist in a specific, fixed location: networking
+cables can only stretch so far, and electrical and optical signals can travel only so fast.
 
-The word "cluster" is often used for small to moderate scale HPC resources less impressive than the [Top-
-500](https://www.top500.org). Clusters are often maintained in computing centers that support several such systems, all sharing
-common networking and storage to support common compute intensive tasks.
+The word "cluster" is often used for small to moderate scale HPC resources less impressive than the
+[Top-500](https://www.top500.org). Clusters are often maintained in computing centers that support
+several such systems, all sharing common networking and storage to support common compute intensive
+tasks.
 
 
 ## Logging in
@@ -52,27 +53,26 @@ Go ahead and log in to the cluster: {{ site.remote.name }} at {{ site.remote.loc
 ```
 {: .bash}
 
-Remember to replace `yourUsername` with the username supplied by the instructors. You will be asked for
-your password. But watch out, the characters you type are not displayed on the screen.
+Remember to replace `yourUsername` with the username supplied by the instructors. You will be asked
+for your password. But watch out, the characters you type are not displayed on the screen.
 
-You are logging in using a program known as the secure shell or `ssh`. 
-This establishes a temporary encrypted connection between your laptop and `{{ site.remote.login }}`.
-The word before the `@` symbol, e.g. `yourUsername` here, is the user account name that Lola has access 
-permissions for on the cluster. 
+You are logging in using a program known as the secure shell or `ssh`. This establishes a temporary
+encrypted connection between your laptop and `{{ site.remote.login }}`. The word before the `@`
+symbol, e.g. `yourUsername` here, is the user account name that Lola has access permissions for on
+the cluster.
 
 > ## Where do I get this `ssh` from ?
 >
 > On Linux and/or macOS, the `ssh` command line utility is almost always pre-installed. Open a
 > terminal and type `ssh --help` to check if that is the case. 
 > 
-> At the time of writing, the openssh support on Microsoft is still very 
-> [recent](https://blogs.msdn.microsoft.com/powershell/2017/12/15/using-the-openssh-beta-in-windows-10-fall-creators-update-and-windows-server-1709/). 
-> Alternatives to this are [putty](http://www.putty.org), 
-> [bitvise SSH](https://www.bitvise.com/ssh-client-download), 
-> [mRemoteNG](https://mremoteng.org/) or [MobaXterm](https://mobaxterm.mobatek.net/). 
-> Download it, install it and open the GUI. The GUI asks for your user name and the destination
-> address or IP of the computer you want to connect to. Once provided, you will be queried for 
-> your password just like in the example above.
+> At the time of writing, the openssh support on Microsoft is still very [recent](
+> https://blogs.msdn.microsoft.com/powershell/2017/12/15/using-the-openssh-beta-in-windows-10-fall-creators-update-and-windows-server-1709/).
+> Alternatives to this are [putty](http://www.putty.org), [bitvise
+> SSH](https://www.bitvise.com/ssh-client-download), [mRemoteNG](https://mremoteng.org/) or
+> [MobaXterm](https://mobaxterm.mobatek.net/). Download it, install it and open the GUI. The GUI
+> asks for your user name and the destination address or IP of the computer you want to connect to.
+> Once provided, you will be queried for your password just like in the example above.
 {: .callout}
 
 ## Where are we?
@@ -134,12 +134,12 @@ available throughout the HPC system.
 
 ## What's in a node? 
 
-All of a HPC system's nodes have the same components as your own laptop or desktop: *CPUs* (sometimes
-also called *processors* or *cores*), *memory* (or *RAM*), and *disk* space. CPUs are a computer's
-tool for actually running programs and calculations. Information about a current task is stored in
-the computer's memory. Disk refers to all storage that can be accessed like a file system. This is
-generally storage that can hold data permanently, i.e. data is still there even if the computer has
-been restarted.
+All of a HPC system's nodes have the same components as your own laptop or desktop: *CPUs*
+(sometimes also called *processors* or *cores*), *memory* (or *RAM*), and *disk* space. CPUs are a
+computer's tool for actually running programs and calculations. Information about a current task is
+stored in the computer's memory. Disk refers to all storage that can be accessed like a file
+system. This is generally storage that can hold data permanently, i.e. data is still there even if
+the computer has been restarted.
 
 {% include figure.html url="" max-width="40%" file="/fig/node_anatomy.png" alt="Node anatomy" caption="" %}
 

--- a/_episodes/14-modules.md
+++ b/_episodes/14-modules.md
@@ -13,8 +13,8 @@ keypoints:
 - "You can edit your `.bashrc` file to automatically load a software package."
 ---
 
-On a high-performance computing system, it is often the case that no software is loaded by default. If we want to use a
-software package, we will need to "load" it ourselves.
+On a high-performance computing system, it is often the case that no software is loaded by default.
+If we want to use a software package, we will need to "load" it ourselves.
 
 Before we start using individual software packages, however, we should understand the reasoning
 behind this approach. The three biggest factors are:

--- a/_episodes/15-transferring-files.md
+++ b/_episodes/15-transferring-files.md
@@ -111,11 +111,11 @@ To recursively copy a directory, we just add the `-r` (recursive) flag:
 > ```
 > {: .bash}
 >
-> The `a` (archive) option preserves file timestamps and permissions among other things; the `v` (verbose)
-> option gives verbose output to help monitor the transfer; the `z` (compression) option compresses
-> the file during transit to reduce size and transfer time; and the `P` (partial/progress) option
-> preserves partially transferred files in case of an interruption and also displays the progress
-> of the transfer.
+> The `a` (archive) option preserves file timestamps and permissions among other things; the `v`
+> (verbose) option gives verbose output to help monitor the transfer; the `z` (compression) option
+> compresses the file during transit to reduce size and transfer time; and the `P`
+> (partial/progress) option preserves partially transferred files in case of an interruption and
+> also displays the progress of the transfer.
 >
 > To recursively copy a directory, we can use the same options:
 >
@@ -185,8 +185,8 @@ The options we used for `tar` are:
 - `-v` - Verbose (print what you are doing!)
 - `-f mydata.tar` - Create the archive in file *output_data.tar*
 
-The tar command allows users to concatenate flags. Instead of typing `tar -c -v -f`, we can use `tar
--cvf`. We can also use the `tar` command to extract the files from the archive once we have
+The tar command allows users to concatenate flags. Instead of typing `tar -c -v -f`, we can use
+`tar -cvf`. We can also use the `tar` command to extract the files from the archive once we have
 transferred it:
 
 ```
@@ -197,11 +197,11 @@ transferred it:
 This will put the data into a directory called `output_data`. Be careful, it will overwrite data
 there if this directory already exists!
 
-Sometimes you may also want to compress the archive to save space and speed up the transfer. However,
-you should be aware that for large amounts of data compressing and un-compressing can take longer
-than transferring the un-compressed data  so you may not want to transfer. To create a compressed
-archive using `tar` we add the `-z` option and add the `.gz` extension to the file to indicate
-it is `gzip`-compressed, e.g.:
+Sometimes you may also want to compress the archive to save space and speed up the transfer.
+However, you should be aware that for large amounts of data compressing and un-compressing can take
+longer than transferring the un-compressed data so you may not want to transfer. To create a
+compressed archive using `tar` we add the `-z` option and add the `.gz` extension to the file to
+indicate it is `gzip`-compressed, e.g.:
 
 ```
 {{ site.local.prompt }} tar -czvf output_data.tar.gz output_data/

--- a/_episodes/16-resources.md
+++ b/_episodes/16-resources.md
@@ -148,7 +148,7 @@ Some interesting fields include the following:
 > > {: .bash}
 > {: .solution}
 {: .challenge}
-  
+
 We can also check on stuff running on the login node right now the same way (so it's 
 not necessary to `ssh` to a node for this example).
 

--- a/_episodes/17-responsiblity.md
+++ b/_episodes/17-responsiblity.md
@@ -178,7 +178,8 @@ transfer earlier.
 > long it will take to transfer your data.
 >
 > Say you have a "data" folder containing 10,000 or so files, a healthy mix of small and large
-> ASCII and binary data. Which of the following would be the best way to transfer them to {{ site.remote.name }}?
+> ASCII and binary data. Which of the following would be the best way to transfer them to
+> {{ site.remote.name }}?
 >
 > 1. ```
 >    {{ site.local.prompt }} scp -r data yourUsername@{{ site.remote.login }}:~/

--- a/_extras/18-nextsteps.md
+++ b/_extras/18-nextsteps.md
@@ -63,9 +63,13 @@ and this will differ from individual to individual!
 > In this exercise, you should try and decide on a good choice of resources and settings
 > on {{ site.remote.name }} for a typical biomolecular system. This will involve:
 >
-> - Downloading the input file for GROMACS from [{{ site.url }}{{site.baseurl }}/files/ion-channel.tpr]({{ site.url }}{{site.baseurl }}/files/ion-channel.tpr)
-> - Writing a job submission script to run GROMACS on {{ site.remote.name }} using the system documentation
-> - Varying the number of nodes (from 1 to 32 nodes is a good starting point) used for the GROMACS job
+> - Downloading the input file for GROMACS from 
+>   [{{ site.url }}{{site.baseurl }}/files/ion-channel.tpr](
+>   {{ site.url }}{{site.baseurl }}/files/ion-channel.tpr)
+> - Writing a job submission script to run GROMACS on {{ site.remote.name }} using the system
+>   documentation
+> - Varying the number of nodes (from 1 to 32 nodes is a good starting point) used for the GROMACS
+>   job
 >   and benchmarking the performance (in ns/day)
 > - Using the results from this study to propose a good resource choice for this GROMACS calculation
 >
@@ -81,9 +85,9 @@ and this will differ from individual to individual!
 
 > ## Running many serial BLAST+ analyses in parallel
 >
-> [BLAST+](https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=Download) finds
-> regions of similarity between biological sequences. The program compares nucleotide or protein
-> sequences to sequence databases and calculates the statistical significance.
+> [BLAST+](https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=Download)
+> finds regions of similarity between biological sequences. The program compares nucleotide or
+> protein sequences to sequence databases and calculates the statistical significance.
 >
 > In this exercise, you should use what you have learnt so far to set up a way to run multiple
 > serial BLAST+ analyses in parallel. There are many different ways to do this that can be used
@@ -95,17 +99,28 @@ and this will differ from individual to individual!
 >
 > We have prepared an example dataset that has 100 sequences to analyse (actually this is 10
 > sequences repeated 10 times). This set is based on the 
-> [BLAST GNU Parallel example](https://github.com/LangilleLab/microbiome_helper/wiki/Quick-Introduction-to-GNU-Parallel)
+> [BLAST GNU Parallel example](
+> https://github.com/LangilleLab/microbiome_helper/wiki/Quick-Introduction-to-GNU-Parallel)
 >
 > This exercise involves:
 >
 > - Downloading and expanding the dataset to the HPC system from:
-    [{{ site.url }}{{site.baseurl }}/files/parallel_example.tar.gz]({{ site.url }}{{site.baseurl }}/files/parallel_example.tar.gz)
-> - Writing a job submission script to run a single analysis using the `blast` module and the command
-    `blastp -db pdb_blast_db_example/pdb_seqres.txt -query test_seq_0.fas -out output_seq_0.blast -evalue 0.0001 -word_size 7 -outfmt "6 std stitle staxids sscinames" -max_target_seqs 10 -num_threads 1` 
->   (note that there will be no output from this alignment if it works correctly).
-> - Choosing a method to run multiple copies of the analysis to complete all 100 analysis tasks in a parallel way
->   (not all 100 have to be run simultaneously)
+>   [{{ site.url }}{{site.baseurl }}/files/parallel_example.tar.gz](
+>   {{ site.url }}{{site.baseurl }}/files/parallel_example.tar.gz)
+> - Writing a job submission script to run a single analysis using the `blast` module and the
+>   following command:
+>
+>   ```
+>   blastp -db pdb_blast_db_example/pdb_seqres.txt -query test_seq_0.fas
+>   -evalue 0.0001 -word_size 7  -max_target_seqs 10 -num_threads 1 \
+>   -out output_seq_0.blast -outfmt "6 std stitle staxids sscinames"
+>   ```
+>   {: .bash}
+>
+>   where the `\` character tells `bash` that the command continues on the next line. Note that
+>   there will be no output from this alignment if it works correctly).
+> - Choosing a method to run multiple copies of the analysis to complete all 100 analysis tasks in a
+>   parallel way (not all 100 have to be run simultaneously).
 >
 > You can explore further by investigating different ways to parallelize this problem and/or
 > combining multiple parallel strategies.

--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -359,15 +359,9 @@ class CheckBase:
         if self.args.line_lengths:
             over = [i for (i, l, n) in self.lines if (n > MAX_LINE_LEN)
                     and (not l.startswith('!'))
-                    and (not l.startswith('http'))
-                    and (not l.startswith('> http'))
-                    and (not l.startswith('> > http'))
-                    and (not l.startswith('{%'))
-                    and (not l.startswith('> {%'))
-                    and (not l.startswith('> > {%'))
-                    and (not l.startswith('{{'))
-                    and (not l.startswith('> {{'))
-                    and (not l.startswith('> > {{'))
+                    and (not 'http' in l)
+                    and (not '{%' in l)
+                    and (not '{{' in l)
             ]
             self.reporter.check(not over,
                                 self.filename,

--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -357,8 +357,18 @@ class CheckBase:
         """Check the raw text of the lesson body."""
 
         if self.args.line_lengths:
-            over = [i for (i, l, n) in self.lines if (
-                n > MAX_LINE_LEN) and (not l.startswith('!'))]
+            over = [i for (i, l, n) in self.lines if (n > MAX_LINE_LEN)
+                    and (not l.startswith('!'))
+                    and (not l.startswith('http'))
+                    and (not l.startswith('> http'))
+                    and (not l.startswith('> > http'))
+                    and (not l.startswith('{%'))
+                    and (not l.startswith('> {%'))
+                    and (not l.startswith('> > {%'))
+                    and (not l.startswith('{{'))
+                    and (not l.startswith('> {{'))
+                    and (not l.startswith('> > {{'))
+            ]
             self.reporter.check(not over,
                                 self.filename,
                                 'Line(s) too long: {0}',

--- a/lesson-outline.md
+++ b/lesson-outline.md
@@ -5,7 +5,10 @@ title: Introduction to HPC Lesson Outline
 
 ## How to use this outline
 
-The following list of items is meant as a guide on what content should go where in this repo. This should work as a guide where you can contribute. If a bullet point is prefixed by a file name, this is the lesson where the listed content should go into. This document is meant as a concept map converted into a flow of learning goals and questions.
+The following list of items is meant as a guide on what content should go where in this repo. This
+should work as a guide where you can contribute. If a bullet point is prefixed by a file name, this
+is the lesson where the listed content should go into. This document is meant as a concept map
+converted into a flow of learning goals and questions.
 
 ## Using a Compute Cluster for Research
 
@@ -13,7 +16,9 @@ The following list of items is meant as a guide on what content should go where 
     * User profiles (academic and/or commercial) of cluster users
     * Narrative introduction
 
-* [11-hpc-intro.md: Intro to Cluster Computing](_episodes/11-hpc-intro.md): Fundamentals of clusters and their resources resources (brief, concentrate on the concepts not details like interconnect type etc)
+* [11-hpc-intro.md: Intro to Cluster Computing](_episodes/11-hpc-intro.md): Fundamentals of
+  clusters and their resources resources (brief, concentrate on the concepts not details like
+  interconnect type etc)
     * Be able to describe what a compute cluster (HPC/HTC system) is
     * Explain how a cluster differs from a laptop, desktop, cloud, or "server"
     * Identify how an compute cluster could benefit you.
@@ -23,36 +28,48 @@ The following list of items is meant as a guide on what content should go where 
     * Understand the purpose of using a terminal program and SSH
     * Learn the basics of working on a remote system
     * Know the differences of between login and compute nodes
-    * Objectives: Connect to a cluster using ssh; Transfer files to and from the cluster; Run the hostname command on a compute node of the cluster.
+    * Objectives: Connect to a cluster using ssh; Transfer files to and from the cluster; Run the
+      hostname command on a compute node of the cluster.
     * Potential tools: ssh, ls, hostname, logout, nproc, free, scp, man, w
-  
-* [13-scheduler.md: Working with the Scheduler](_episodes/13-scheduler.md): Lesson will cover SLURM by default, other schedulers are planned.  From [hpc-in-a-day](https://github.com/psteinb/hpc-in-a-day) we know that material comprising Slurm, PBS and LSF is possible, but hard already as e.g. PBS doesn't support direct dispatchment as `srun`.
+
+* [13-scheduler.md: Working with the Scheduler](_episodes/13-scheduler.md): Lesson will cover SLURM
+  by default, other schedulers are planned. From
+  [hpc-in-a-day](https://github.com/psteinb/hpc-in-a-day) we know that material comprising Slurm,
+  PBS and LSF is possible, but hard already as e.g. PBS doesn't support direct dispatchment as
+  `srun`.
     * Know how to submit a program and batch scrip to the cluster (interactive & batch)
     * Use the batch system command line tools to monitor the execution of your job.
     * Inspect the output and error files of your jobs.
-    * Potential tools: shell script, sbatch, squeue -u, watch, -N, -n, -c, --mem, --time, scancel, srun, --x11 --pty, 
-    * Extras: --mail-user, --mail-type, 
-    * Remove? watch, 
-    * Later lessons? -N -n -c
-    
+    * Potential tools: shell script, `sbatch`, `squeue -u`, `watch`, `-N`, `-n`, `-c`, `--mem`,
+      `--time`, `scancel`, `srun`, `--x11 --pty`,
+    * Extras: `--mail-user`, `--mail-type`, 
+    * Remove? `watch` 
+    * Later lessons? `-N` `-n` `-c`
+
 * [14-modules.md: Accessing Software](_episodes/14-modules.md)
     * Understand the runtime environment at login
     * Learn how software modules can modify your environment
     * Learn how modules prevent problems and promote reproducibility
     * Objectives: how to load and use a software package.
-    * Tools: module avail, module load, which, echo $PATH, module list, module unload, module purge, .bashrc, .bash_profile, git clone, make, 
+    * Tools: module avail, module load, which, echo $PATH, module list, module unload, module
+      purge, .bashrc, .bash_profile, git clone, make,
     * Remove: make, git clone, 
     * Extras: .bashrc, .bash_profile
 
-* [15-Filesystems and Storage]: This topic didn't get fleshed out in the call. But objectives likely include items from PStein's [Shared Filesystem lesson](https://github.com/psteinb/hpc-in-a-day/blob/gh-pages/_episodes/01-04-shared-filesystem.md):
+* [15-Filesystems and Storage]: This topic didn't get fleshed out in the call. But objectives
+  likely include items from PStein's [Shared Filesystem lesson](
+  https://github.com/psteinb/hpc-in-a-day/blob/gh-pages/_episodes/01-04-shared-filesystem.md):
     * Understand the difference between a local and shared/network filesystem
     * Learn about high performance / scratch Filesystems
-    * Raise the attention that misuse (intentional or not) of a common file system negatively affects all users very quickly.
+    * Raise the attention that misuse (intentional or not) of a common file system negatively
+      affects all users very quickly.
     * Possible tools: echo $TEMP, ls -al /tmp, df, quota
 
 * [15-transferring-files.md: Transferring Files](_episodes/15-transferring-files.md)
-    * Understand the (cognitive) limitations that remote systems don't necessarily have local Finder/Explorer windows
-    * Be mindful of network and speed restrictions (e.g. cannot push from cluster; many files vs one archive)
+    * Understand the (cognitive) limitations that remote systems don't necessarily have local
+      Finder/Explorer windows
+    * Be mindful of network and speed restrictions (e.g. cannot push from cluster; many files vs
+      one archive)
     * Know what tools can be used for file transfers, and transfer modes (binary vs text)
     * Objective: Be able to transfer files to and from a computing cluster.
     * Tools: wget, scp, rsync (callout), mkdir, FileZilla, 
@@ -65,13 +82,16 @@ The following list of items is meant as a guide on what content should go where 
     * Learn how to use job statistics to understand the health of your jobs
     * Learn some very basic techniques to monitor / profile code execution.
     * Understand job size and resource request implications.
-    * Tools: fastqc, sacct, ssh, top, free, ps, kill, killall (note that some of these may not be appropriate on shared systems)
+    * Tools: fastqc, sacct, ssh, top, free, ps, kill, killall (note that some of these may not be
+      appropriate on shared systems)
 
 
 ## Previous lesson ideas, up for debate
 
 
-* Playing friendly in the cluster (psteinb: the following is very tricky as it is site dependent, I personally would like to see it in [_extras](https://github.com/hpc-carpentry/hpc-intro/tree/gh-pages/_extras))
+* Playing friendly in the cluster (psteinb: the following is very tricky as it is site dependent, I
+  personally would like to see it in
+  [_extras](https://github.com/hpc-carpentry/hpc-intro/tree/gh-pages/_extras))
 	* Understanding resource utilisation
 	* Profiling code - time, size, etc.
 	* Getting system stats
@@ -79,16 +99,20 @@ The following list of items is meant as a guide on what content should go where 
 
 
 * `Advanced-jobs.md` (doesn't exist yet)
-	* Checking status of jobs (`squeue`, `bjobs` etc.), explain different job states and relate to scheduler basics
+	* Checking status of jobs (`squeue`, `bjobs` etc.), explain different job states and relate to
+      scheduler basics
 	* Cancelling/deleting a job (`scancel`, `bkill` etc.)
 	* Passing options to the scheduler (log files)
 	* Callout: Changing a job's name
 	* Optional Callout: Send an email once the job completes (not all sites support sending emails)
-	* for a starting point, see [this](https://psteinb.github.io/hpc-in-a-day/02-02-advanced-job-scheduling/) for reference
-        
-        
+	* for a starting point, see [this](
+      https://psteinb.github.io/hpc-in-a-day/02-02-advanced-job-scheduling/) for reference
+
+
 * `Filesystem-zoo.md` (doesn't exist yet)
     * execute a job that collects node information and stores the output to `/tmp`
     * ask participants where the output went and why they can't see it
-    * execute a job that collects node information and stores the output to `/shared` or however your shared file system is called
-    * for a starting point, see [this](https://psteinb.github.io/hpc-in-a-day/02-03-shared-filesystem/) for reference
+    * execute a job that collects node information and stores the output to `/shared` or however
+      your shared file system is called
+    * for a starting point, see [this](
+      https://psteinb.github.io/hpc-in-a-day/02-03-shared-filesystem/) for reference

--- a/reference.md
+++ b/reference.md
@@ -9,7 +9,8 @@ permalink: /reference/
 
 ## Glossary
 
-The following list captures terms that need to be added to this glossary. This is a great way to contribute.
+The following list captures terms that need to be added to this glossary. This is a great way to
+contribute.
 
 {:auto_ids}
 [Accelerator](https://en.wikipedia.org/wiki/Hardware_acceleration)
@@ -38,7 +39,8 @@ The following list captures terms that need to be added to this glossary. This i
 [High availability computing](https://en.wikipedia.org/wiki/High_availability)
 :    *to be defined*
 
-[High performance computing](https://en.wikipedia.org/w/index.php?title=High-performance_computing&redirect=no)
+[High performance computing](
+https://en.wikipedia.org/w/index.php?title=High-performance_computing&redirect=no)
 :    *to be defined*
 
 [Interconnect](https://en.wikipedia.org/wiki/Supercomputer_architecture)
@@ -63,7 +65,8 @@ The following list captures terms that need to be added to this glossary. This i
 :    *to be defined*
 
 [Supercomputer](https://en.wikipedia.org/wiki/Supercomputer)
-:    ... "[a major scientific instrument](https://www.hpcnotes.com/2015/10/essential-analogies-for-hpc-advocate.html)" ...
+:    ... "[a major scientific instrument](
+https://www.hpcnotes.com/2015/10/essential-analogies-for-hpc-advocate.html)" ...
 
 [Workstation](https://en.wikipedia.org/wiki/Workstation)
 :    *to be defined*


### PR DESCRIPTION
`make lesson-check-all` warns about numerous files containing excessively long lines.
Some are URLs or templated commands, which are best left alone. Most are, indeed,
quite long. This PR excuses the former, and addresses the latter.