### PR TITLE
Name to job ~and change order of commands~

### DIFF
--- a/_episodes/13-scheduler.md
+++ b/_episodes/13-scheduler.md
@@ -251,11 +251,12 @@ minutes.
 
 ```
 #!/bin/bash
+{{ site.sched.comment }} {{ site.sched.flag.name }} long_job
 {{ site.sched.comment }} {{ site.sched.flag.time }} 00:00:30
 
 echo -n "This script is running on "
-sleep 120 # time in seconds
 hostname
+sleep 120 # time in seconds
 echo "This script has finished successfully."
 ```
 {: .output}

--- a/_episodes/13-scheduler.md
+++ b/_episodes/13-scheduler.md
@@ -254,7 +254,7 @@ minutes.
 {{ site.sched.comment }} {{ site.sched.flag.name }} long_job
 {{ site.sched.comment }} {{ site.sched.flag.time }} 00:00:30
 
-echo -n "This script is running on ..."
+echo -n "This script is running on ... "
 sleep 120 # time in seconds
 hostname
 echo "This script has finished successfully."

--- a/_episodes/13-scheduler.md
+++ b/_episodes/13-scheduler.md
@@ -254,9 +254,9 @@ minutes.
 {{ site.sched.comment }} {{ site.sched.flag.name }} long_job
 {{ site.sched.comment }} {{ site.sched.flag.time }} 00:00:30
 
-echo -n "This script is running on "
-hostname
+echo -n "This script is running on ..."
 sleep 120 # time in seconds
+hostname
 echo "This script has finished successfully."
 ```
 {: .output}


### PR DESCRIPTION
It would make a good practice to name the job so it's easier to find it on the queue.
Also, it makes more sense to me that the `echo` and `hostname` are printed together before `sleep` starts.
