### PR TITLE
Add task force volunteers from CarpentryCon@Home

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,4 @@
 # Each line is a file pattern followed by one or more owners.
 # The sequence matters: later patterns take precedence.
 
-*       steinbach@scionics.de ckoch5@wisc.edu
-
+*  @psteinb @ChristinaLK @tkphd @megan-guidry @reid-a @mikerenfro @annajiat @colinsauze


### PR DESCRIPTION
- Rename file to match GitHub's requirement (SHOUTYCASE)
- Add folks who volunteered [here](https://pad.carpentries.org/cchome-hpc-carpentry) to automatically receive review requests