### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -47,7 +47,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        SITE_CONFIG: [ComputeCanada_Graham_slurm, EPCC_Cirrus_pbs, Norway_SIGMA2_SAGA_slurm, UCL_Myriad_sge]
+        SITE_CONFIG:
+          - ComputeCanada_Graham_slurm
+          - EPCC_Cirrus_pbs
+          - NIST_CTCMS_slurm
+          - Norway_SIGMA2_SAGA_slurm
+          - UCL_Myriad_sge
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-ruby@v1

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - gh-pages
+      - github_actions
 
 jobs:
   spellcheck:

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -1,0 +1,65 @@
+name: Check lesson and build for all configs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - gh-pages
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install codespell
+      run: |
+        pip3 install codespell
+    - name: Check spelling
+      run: |
+        codespell --skip="assets,*.svg,bin" --quiet-level=2  -L "rouge,dropse,namd,hist"
+
+  check_lesson_and_build_default:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
+    - name: Install basic requirements
+      run: |
+        # Need this library for nokogiri
+        sudo apt-get install libxslt1-dev    
+        gem install bundler jekyll json kramdown
+        bundle config set path '.vendor/bundle'
+        bundle config build.nokogiri --use-system-libraries
+    - name: "Check lesson"
+      run: |
+        make lesson-check-all
+    - name: "Check build"
+      run: |
+        make --always-make site
+
+  build-specific-sites:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        SITE_CONFIG: [ComputeCanada_Graham_slurm, EPCC_Cirrus_pbs, Norway_SIGMA2_SAGA_slurm, UCL_Myriad_sge]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
+    - name: Install basic requirements
+      run: |
+        # Need this library for nokogiri
+        sudo apt-get install libxslt1-dev    
+        gem install bundler jekyll json kramdown
+        bundle config set path '.vendor/bundle'
+        bundle config build.nokogiri --use-system-libraries
+    - name: Check build ${{matrix.SITE_CONFIG}}
+      run: |
+        make --always-make site SITE_CONFIG=_includes/snippets_library/${{matrix.SITE_CONFIG}}/_config_options.yml


### PR DESCRIPTION
This adds a GitHub Actions workflow for CI, which we can ultimately use to replace Travis. The jobs are run in parallel so CI time is about 5-6 minutes. Actually building the lesson is trivial (seconds) so there isn't really much point to the parallelism, we could just reuse the environment from one case. The only thing is how easy it would be to add additional sites with the way I've implemented it.