### PR TITLE
See if we can shorten CI time

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         # Need this library for nokogiri
         sudo apt-get install libxslt1-dev    
-        gem install bundler
+        gem install bundler json
         bundle config set path '.vendor/bundle'
         bundle config build.nokogiri --use-system-libraries
         bundle install

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         # Need this library for nokogiri
         sudo apt-get install libxslt1-dev    
-        gem install bundler json
+        gem install bundler json kramdown
         bundle config set path '.vendor/bundle'
         bundle config build.nokogiri --use-system-libraries
         bundle install

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -36,6 +36,7 @@ jobs:
         gem install bundler
         bundle config set path '.vendor/bundle'
         bundle config build.nokogiri --use-system-libraries
+        bundle install
     - name: "Check lesson for warnings"
       run: |
         make lesson-check-all
@@ -68,6 +69,7 @@ jobs:
         gem install bundler
         bundle config set path '.vendor/bundle'
         bundle config build.nokogiri --use-system-libraries
+        bundle install
     - name: Check build ${{matrix.SITE_CONFIG}}
       run: |
         make --always-make site SITE_CONFIG=_includes/snippets_library/${{matrix.SITE_CONFIG}}/_config_options.yml

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         # Need this library for nokogiri
         sudo apt-get install libxslt1-dev    
-        gem install bundler jekyll json kramdown
+        gem install bundler
         bundle config set path '.vendor/bundle'
         bundle config build.nokogiri --use-system-libraries
     - name: "Check lesson for warnings"
@@ -65,7 +65,7 @@ jobs:
       run: |
         # Need this library for nokogiri
         sudo apt-get install libxslt1-dev    
-        gem install bundler jekyll json kramdown
+        gem install bundler
         bundle config set path '.vendor/bundle'
         bundle config build.nokogiri --use-system-libraries
     - name: Check build ${{matrix.SITE_CONFIG}}


### PR DESCRIPTION
I noticed that we are installing 2 different versions of Jekyll and I was wondering if we can drop one of these. 