### PR TITLE
queues and default partition error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,9 @@ sched:
   submit:
     name: "sbatch"
     options: ""
+  queue:
+    debug: "debug"
+    testing: "testing"
   status: "squeue"
   flag:
     user: "-u yourUsername"
@@ -52,11 +55,6 @@ sched:
   info: "sinfo"
   comment: "#SBATCH"
   hist: "sacct -u yourUsername"
-
-# Interactive queue names, one or more as a list
-workshop_interactive_queues:
-  - debug
-  - testing
 
 #------------------------------------------------------------
 # Values for this lesson

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/_config_options.yml
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/_config_options.yml
@@ -37,6 +37,9 @@ sched:
   submit:
     name: "sbatch"
     options: ""
+  queue:
+    debug: "debug"
+    testing: "testing"
   status: "squeue"
   flag:
     user: "-u yourUsername"
@@ -49,8 +52,3 @@ sched:
   info: "sinfo"
   comment: "#SBATCH"
   hist: "sacct -u yourUsername"
-
-# Interactive queue names, one or more as a list
-workshop_interactive_queues:
-  - debug
-  - testing

--- a/_includes/snippets_library/EPCC_Cirrus_pbs/_config_options.yml
+++ b/_includes/snippets_library/EPCC_Cirrus_pbs/_config_options.yml
@@ -38,6 +38,9 @@ sched:
     name: "qsub"
     options: "-A tc001 -q R387726"
     iopt: ""
+  queue:
+    debug: "standard"
+    testing: "standard"
   status: "qstat"
   flag:
     user: "-u yourUsername"
@@ -50,8 +53,3 @@ sched:
   info: "pbsnodes -a"
   comment: "#PBS"
   hist: "qstat -x"
-
-# Interactive queue names, one or more as a list
-workshop_interactive_queues:
-  - debug
-  - testing

--- a/_includes/snippets_library/NIST_CTCMS_slurm/12/queue-info.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/12/queue-info.snip
@@ -17,8 +17,8 @@ rack6i       up 30-00:00:0      2   idle r[059-060]
 rack6        up 30-00:00:0      1 drain* r057
 rack6        up 30-00:00:0      1  down* r053
 rack6        up 30-00:00:0      5  alloc r[052,054-056,058]
-fast         up   12:00:00      1   idle r001
-serial       up 14-00:00:0      1   idle r002
+{{ site.sched.queue.testing }}         up   12:00:00      1   idle r001
+{{ site.sched.queue.debug }}       up 14-00:00:0      1   idle r002
 gpu          up 7-00:00:00      3   idle rgpu,rgpu[4-5]
 gpu          up 7-00:00:00      2   down rgpu[2-3]
 ```

--- a/_includes/snippets_library/NIST_CTCMS_slurm/13/basic-job-status.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/13/basic-job-status.snip
@@ -1,6 +1,6 @@
 ```
  JOBID PARTITION     NAME            USER ST       TIME  NODES NODELIST(REASON)
-212201    serial example-    yourUsername  R       0:05      1 r002
+212201    {{ site.sched.queue.debug }} example-    yourUsername  R       0:05      1 r002
 ```
 {: .output}
 

--- a/_includes/snippets_library/NIST_CTCMS_slurm/13/job-with-name-status.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/13/job-with-name-status.snip
@@ -1,6 +1,6 @@
 ```
   JOBID PARTITION     NAME          USER ST       TIME  NODES NODELIST(REASON)
- 212202    serial new_name  yourUsername  R       0:02      1 r002
+ 212202    {{ site.sched.queue.debug }} new_name  yourUsername  R       0:02      1 r002
 
 ```
 {: .output}

--- a/_includes/snippets_library/NIST_CTCMS_slurm/13/terminate-job-begin.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/13/terminate-job-begin.snip
@@ -2,7 +2,7 @@
 Submitted batch job 212203
 
   JOBID PARTITION     NAME          USER ST       TIME  NODES NODELIST(REASON)
- 212203    serial new_name  yourUsername  R       0:03      1 r002
+ 212203    {{ site.sched.queue.debug }} new_name  yourUsername  R       0:03      1 r002
 
 ```
 {: .output}

--- a/_includes/snippets_library/NIST_CTCMS_slurm/16/account-history.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/16/account-history.snip
@@ -1,16 +1,16 @@
 ```
       JobID    JobName  Partition    Account  AllocCPUS      State ExitCode 
 ------------ ---------- ---------- ---------- ---------- ---------- -------- 
-212339         hostname     serial       root          2  COMPLETED      0:0 
-212340         hostname     serial       root          2  COMPLETED      0:0 
-212341              env     serial       root          2  COMPLETED      0:0 
-212342           mpirun       fast       root          2  COMPLETED      0:0 
-212343           mpirun       fast       root          2  COMPLETED      0:0 
-212344              cpi       fast       root          2  COMPLETED      0:0 
-212345              cpi       fast       root          2  COMPLETED      0:0 
-212346             bash       fast       root          2  COMPLETED      0:0 
+212339         hostname     {{ site.sched.queue.debug }}       root          2  COMPLETED      0:0 
+212340         hostname     {{ site.sched.queue.debug }}       root          2  COMPLETED      0:0 
+212341              env     {{ site.sched.queue.debug }}       root          2  COMPLETED      0:0 
+212342           mpirun       {{ site.sched.queue.testing }}       root          2  COMPLETED      0:0 
+212343           mpirun       {{ site.sched.queue.testing }}       root          2  COMPLETED      0:0 
+212344              cpi       {{ site.sched.queue.testing }}       root          2  COMPLETED      0:0 
+212345              cpi       {{ site.sched.queue.testing }}       root          2  COMPLETED      0:0 
+212346             bash       {{ site.sched.queue.testing }}       root          2  COMPLETED      0:0 
 212346.0           bash                  root          2  COMPLETED      0:0 
 212346.1            cpi                  root          2  COMPLETED      0:0 
-212347              cpi       fast       root          2     FAILED      1:0 
+212347              cpi       {{ site.sched.queue.testing }}       root          2     FAILED      1:0 
 ```
 {: .output}

--- a/_includes/snippets_library/NIST_CTCMS_slurm/_config_options.yml
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/_config_options.yml
@@ -36,7 +36,7 @@ sched:
   name: "SLURM"
   submit:
     name: "sbatch"
-    options: ""
+    options: "--partition=serial"
   status: "squeue"
   flag:
     user: "-u yourUsername"

--- a/_includes/snippets_library/NIST_CTCMS_slurm/_config_options.yml
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/_config_options.yml
@@ -37,6 +37,9 @@ sched:
   submit:
     name: "sbatch"
     options: "--partition=serial"
+  queue:
+    debug: "serial"
+    testing: "fast"
   status: "squeue"
   flag:
     user: "-u yourUsername"
@@ -49,8 +52,3 @@ sched:
   info: "sinfo"
   comment: "#SBATCH"
   hist: "sacct -u yourUsername"
-
-# Interactive queue names, one or more as a list
-workshop_interactive_queues:
-  - fast
-  - serial

--- a/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/_config_options.yml
+++ b/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/_config_options.yml
@@ -37,6 +37,9 @@ sched:
   submit:
     name: "sbatch"
     options: ""
+  queue:
+    debug: "devel"
+    testing: "normal"
   status: "squeue"
   flag:
     user: "-u yourUsername"
@@ -49,8 +52,3 @@ sched:
   info: "sinfo"
   comment: "#SBATCH"
   hist: "sacct -u $USER"
-
-# Interactive queue names, one or more as a list
-workshop_interactive_queues:
-  - normal
-  - devel

--- a/_includes/snippets_library/UCL_Myriad_sge/_config_options.yml
+++ b/_includes/snippets_library/UCL_Myriad_sge/_config_options.yml
@@ -31,8 +31,3 @@ sched:
   info: "qhost"
   comment: "#$ "
   hist: "jobhist"
-
-# Interactive queue names, one or more as a list
-workshop_interactive_queues:
-  - debug
-  - testing


### PR DESCRIPTION
Mostly tweaking the CTCMS config & library to specify a partition, since there is no default on that cluster.
Also moved the queue variables into the nested array of variables, and invoke them in the CTCMS snippets.
Adoption elsewhere is up to the cluster maintainers.

Closes #150.